### PR TITLE
feat: 로그인/회원가입 라우트에 Suspense + ErrorBoundary 도입

### DIFF
--- a/.claude/rules/page-patterns.md
+++ b/.claude/rules/page-patterns.md
@@ -85,48 +85,121 @@ export default async function ProfilePage({ params }: PageProps) {
 ## 로딩 UI (`loading.tsx`)
 
 페이지 단위 Streaming을 활용한다. React Suspense가 자동으로 적용된다.
+**데이터 패칭이 있는 세그먼트에는 `loading.tsx`를 배치한다.** 데이터 패칭이 없는 정적 페이지는 생략 가능.
 
 ```tsx
 // app/candidates/loading.tsx
-export default function Loading() {
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function CandidatesLoading() {
   return (
     <div className="space-y-4 p-6">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <div
-          key={i}
-          className="h-40 animate-pulse rounded-2xl bg-rose-50"
-        />
-      ))}
+      <Skeleton className="h-8 w-40" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="h-40 rounded-2xl" />
+        <Skeleton className="h-40 rounded-2xl" />
+        <Skeleton className="h-40 rounded-2xl" />
+      </div>
     </div>
   );
 }
 ```
 
-실제 레이아웃을 모방하는 Skeleton을 쓴다. "로딩 중..." 텍스트만 표시하는 것은 금지.
+**규칙**
+- 실제 레이아웃 크기/간격을 모방한다. "로딩 중..." 텍스트만 표시하는 것은 금지.
+- Skeleton은 `components/ui/skeleton.tsx`의 `Skeleton` 컴포넌트를 재사용한다. 별도 placeholder 컴포넌트를 새로 만들지 않는다.
+- `loading.tsx`에 무거운 클라이언트 컴포넌트(애니메이션, 차트 등)를 넣지 않는다 — fallback은 가볍게 유지한다.
+- 함수명은 `<Route>Loading` (예: `DashboardLoading`, `LoginLoading`).
 
 ## 에러 UI (`error.tsx`)
+
+렌더/데이터 패칭 중 throw된 예외를 세그먼트 경계에서 잡는다. React Error Boundary로 감싸진다.
 
 ```tsx
 // app/candidates/error.tsx
 "use client"; // error.tsx는 반드시 클라이언트 컴포넌트
 
-type ErrorProps = {
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+type CandidatesErrorProps = {
   error: Error & { digest?: string };
   reset: () => void;
 };
 
-export default function Error({ error, reset }: ErrorProps) {
+export default function CandidatesError({ error, reset }: CandidatesErrorProps) {
+  useEffect(() => {
+    console.error("[candidates] route error:", error);
+  }, [error]);
+
   return (
     <div className="flex flex-col items-center gap-4 p-12 text-center">
-      <p className="text-lg font-semibold text-foreground">오류가 발생했습니다</p>
-      <p className="text-sm text-muted-foreground">{error.message}</p>
-      <Button variant="outline" onClick={reset}>
+      <h2 className="text-foreground">오류가 발생했습니다</h2>
+      <p className="text-sm text-muted-foreground">잠시 후 다시 시도해 주세요.</p>
+      {error.digest ? (
+        <p className="text-xs text-muted-foreground">오류 코드: {error.digest}</p>
+      ) : null}
+      <Button variant="outline" onClick={reset} className="rounded-full">
         다시 시도
       </Button>
     </div>
   );
 }
 ```
+
+**규칙**
+- `"use client"` 필수. props 타입은 `{ error: Error & { digest?: string }; reset: () => void }` (interface 금지).
+- 함수명은 `<Route>Error` (예: `LoginError`, `DashboardError`).
+- `useEffect`에서 `console.error`로 로깅한다 — 프로덕션에서 관찰 가능성 확보.
+- `error.message`를 사용자에게 그대로 노출하지 않는다. 내부 정보가 유출될 수 있다. 사용자 친화 메시지 + 필요 시 `error.digest`만 노출.
+- `reset()` 버튼과 복귀 링크(홈/상위 경로) 두 가지 액션을 제공한다.
+- **형제 `layout.tsx`의 에러는 잡지 못한다.** 레이아웃까지 감싸려면 부모 세그먼트에 `error.tsx`를 둔다.
+- Server Action 실패 같은 **폼 내부 에러**는 `setError()`로 인라인 표시 — `error.tsx`로 올리지 않는다 (`form-patterns.md` 참조).
+
+## Suspense 바운더리 — 파일 레벨 vs 컴포넌트 레벨
+
+Suspense 배치는 두 가지 층위로 결정한다.
+
+| 층위 | 사용 상황 | 방법 |
+|------|-----------|------|
+| **파일 레벨 (`loading.tsx`)** | 세그먼트 전체가 한 덩어리로 스트리밍되어도 무방 | `loading.tsx` 배치만으로 충분 |
+| **컴포넌트 레벨 (`<Suspense>`)** | 헤더/네비는 즉시 보이고, 느린 데이터 영역만 스트리밍하고 싶을 때 | 페이지에서 Promise를 하위 서버 컴포넌트에 넘기고 `<Suspense>`로 래핑 |
+
+### 컴포넌트 레벨 Suspense 예시
+
+```tsx
+// app/(member)/dashboard/page.tsx
+import { Suspense } from "react";
+import { GlobalNav } from "@/components/global-nav";
+import { DashboardStreamingSkeleton } from "@/components/dashboard-streaming-skeleton";
+import { requireApprovedMembership } from "@/lib/permissions";
+import { DashboardMain } from "./dashboard-main";
+
+export default async function DashboardPage() {
+  const membership = await requireApprovedMembership(); // 빠른 체크는 await
+
+  return (
+    <>
+      <GlobalNav membership={membership} />
+      <Suspense fallback={<DashboardStreamingSkeleton />}>
+        {/* DashboardMain 내부에서 무거운 데이터 패칭 */}
+        <DashboardMain membership={membership} />
+      </Suspense>
+    </>
+  );
+}
+```
+
+**판단 기준**
+- 페이지 최상단에 **즉시 보여줄 UI(네비게이션, 헤더 등)가 있다** → 컴포넌트 레벨 `<Suspense>` 사용
+- 데이터 패칭이 **여러 독립 영역**으로 나뉜다 → 영역별로 `<Suspense>` 분리해 각각 스트리밍
+- 그 외 단순 페이지 → `loading.tsx`만으로 충분
+
+### Not Found vs Error 우선순위
+
+`notFound()` 호출 시 `error.tsx`가 아닌 `not-found.tsx`가 렌더된다. 도메인적 "없음"과 예외를 구분한다:
+- **데이터 없음** → `notFound()` + `not-found.tsx`
+- **예외/쿼리 실패** → throw → `error.tsx`
 
 ## Not Found (`not-found.tsx`)
 
@@ -193,7 +266,10 @@ export default async function DashboardPage() {
 2. `params`는 반드시 `await` — `Promise<{ id: string }>` 타입
 3. 여러 데이터 패칭은 `Promise.all()` 병렬 실행
 4. 페이지에 UI 로직 금지 — 컴포넌트에 위임
-5. 주요 경로에 `loading.tsx`, `error.tsx` 배치
-6. `loading.tsx`는 Skeleton으로 실제 레이아웃 모방
-7. 데이터 없음은 `notFound()` 호출 + `not-found.tsx`로 처리
-8. **인증**은 `middleware.ts`에서, **인가**(역할/권한)는 페이지에서 처리
+5. **데이터 패칭이 있는 모든 세그먼트에 `loading.tsx` + `error.tsx` 배치**
+6. `loading.tsx`는 `components/ui/skeleton.tsx`의 `Skeleton`을 재사용해 실제 레이아웃 모방
+7. `error.tsx`는 `"use client"` + `useEffect` 로깅 + `reset()` 버튼 + 복귀 링크
+8. `error.message`를 사용자에게 노출 금지 — 친화 메시지 + `error.digest`만
+9. 즉시 보여줄 UI가 있거나 데이터 영역이 여러 개면 **컴포넌트 레벨 `<Suspense>`** 사용
+10. 데이터 없음은 `notFound()` 호출 + `not-found.tsx`로 처리 (예외와 구분)
+11. **인증**은 `middleware.ts`에서, **인가**(역할/권한)는 페이지에서 처리

--- a/app/(public)/login/error.tsx
+++ b/app/(public)/login/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { CupidLogo } from "@/components/cupid-logo";
+
+type LoginErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function LoginError({ error, reset }: LoginErrorProps) {
+  useEffect(() => {
+    console.error("[login] route error:", error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center overflow-x-hidden bg-gradient-to-br from-rose-50 via-pink-50/30 to-orange-50/50 px-4 py-10">
+      <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(circle_at_top,rgba(255,242,245,0.84),rgba(255,247,243,0.68),rgba(255,255,255,0.38))]" />
+
+      <div className="relative z-[1] flex w-full max-w-md flex-col items-center gap-8 text-center">
+        <div className="flex size-11 items-center justify-center rounded-[20px] border border-border/40 bg-card/70 text-primary shadow-sm">
+          <CupidLogo size={24} />
+        </div>
+
+        <div className="flex w-full flex-col items-center gap-4 rounded-[28px] border border-border/40 bg-card/80 p-8 shadow-md backdrop-blur-sm">
+          <h2 className="text-foreground">로그인 화면을 불러오지 못했어요</h2>
+          <p className="text-[15px] leading-7 text-muted-foreground">
+            일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
+          </p>
+          {error.digest ? (
+            <p className="text-xs text-muted-foreground">오류 코드: {error.digest}</p>
+          ) : null}
+
+          <div className="mt-2 flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+            <Button onClick={reset} className="rounded-full">
+              다시 시도
+            </Button>
+            <Button variant="outline" className="rounded-full" render={<Link href="/" />}>
+              홈으로
+            </Button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(public)/login/loading.tsx
+++ b/app/(public)/login/loading.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function LoginLoading() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center overflow-x-hidden bg-gradient-to-br from-rose-50 via-pink-50/30 to-orange-50/50 px-4 py-10">
+      <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(circle_at_top,rgba(255,242,245,0.84),rgba(255,247,243,0.68),rgba(255,255,255,0.38))]" />
+
+      <div className="relative z-[1] flex w-full max-w-md flex-col items-center gap-8">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-11 rounded-[20px]" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-40" />
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col gap-4 rounded-[28px] border border-border/40 bg-card/70 p-6 shadow-md">
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="h-4 w-56" />
+          <div className="mt-2 flex flex-col gap-3">
+            <Skeleton className="h-11 w-full rounded-xl" />
+            <Skeleton className="h-11 w-full rounded-xl" />
+          </div>
+          <Skeleton className="mt-2 h-12 w-full rounded-full" />
+          <Skeleton className="mx-auto h-4 w-40" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(public)/signup/error.tsx
+++ b/app/(public)/signup/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { CupidLogo } from "@/components/cupid-logo";
+
+type SignupErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function SignupError({ error, reset }: SignupErrorProps) {
+  useEffect(() => {
+    console.error("[signup] route error:", error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center overflow-x-hidden bg-gradient-to-br from-rose-50 via-pink-50/30 to-orange-50/50 px-4 py-10">
+      <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(circle_at_top,rgba(255,242,245,0.84),rgba(255,247,243,0.68),rgba(255,255,255,0.38))]" />
+
+      <div className="relative z-[1] flex w-full max-w-md flex-col items-center gap-8 text-center">
+        <div className="flex size-11 items-center justify-center rounded-[20px] border border-border/40 bg-card/70 text-primary shadow-sm">
+          <CupidLogo size={24} />
+        </div>
+
+        <div className="flex w-full flex-col items-center gap-4 rounded-[28px] border border-border/40 bg-card/80 p-8 shadow-md backdrop-blur-sm">
+          <h2 className="text-foreground">회원가입 화면을 불러오지 못했어요</h2>
+          <p className="text-[15px] leading-7 text-muted-foreground">
+            일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
+          </p>
+          {error.digest ? (
+            <p className="text-xs text-muted-foreground">오류 코드: {error.digest}</p>
+          ) : null}
+
+          <div className="mt-2 flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+            <Button onClick={reset} className="rounded-full">
+              다시 시도
+            </Button>
+            <Button variant="outline" className="rounded-full" render={<Link href="/login" />}>
+              로그인으로
+            </Button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(public)/signup/loading.tsx
+++ b/app/(public)/signup/loading.tsx
@@ -1,0 +1,49 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SignupLoading() {
+  return (
+    <main className="flex min-h-screen flex-col items-center overflow-x-hidden bg-gradient-to-br from-rose-50 via-pink-50/30 to-orange-50/50 px-4 py-10 lg:py-16">
+      <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(circle_at_top,rgba(255,242,245,0.84),rgba(255,247,243,0.68),rgba(255,255,255,0.38))]" />
+
+      <div className="relative z-[1] flex w-full max-w-4xl flex-col items-center gap-8">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-11 rounded-[20px]" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-40" />
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col items-center gap-3">
+          <Skeleton className="h-8 w-72" />
+          <Skeleton className="h-4 w-full max-w-[48ch]" />
+          <Skeleton className="h-4 w-5/6 max-w-[44ch]" />
+        </div>
+
+        <div className="grid w-full grid-cols-1 items-start gap-8 lg:grid-cols-2">
+          <div className="order-2 flex flex-col gap-4 rounded-[28px] border border-border/40 bg-card/70 p-6 shadow-md lg:order-1">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+            <div className="mt-2 flex flex-col gap-3">
+              <Skeleton className="h-12 w-full rounded-2xl" />
+              <Skeleton className="h-12 w-full rounded-2xl" />
+            </div>
+          </div>
+
+          <div className="order-1 flex flex-col gap-4 rounded-[28px] border border-border/40 bg-card/70 p-6 shadow-md lg:order-2">
+            <Skeleton className="h-5 w-24" />
+            <Skeleton className="h-4 w-56" />
+            <div className="mt-2 flex flex-col gap-3">
+              <Skeleton className="h-11 w-full rounded-xl" />
+              <Skeleton className="h-11 w-full rounded-xl" />
+              <Skeleton className="h-11 w-full rounded-xl" />
+            </div>
+            <Skeleton className="mt-2 h-12 w-full rounded-full" />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 배경
로그인/회원가입 경로에 세그먼트 단위의 로딩·에러 폴백이 없어서, 네트워크 지연이나 예외 발생 시 빈 화면 또는 크래시가 노출되는 위험이 있었다. Next.js App Router 컨벤션에 맞춰 Suspense(`loading.tsx`)와 Error Boundary(`error.tsx`)를 도입한다.

## 변경 내용
- **app/(public)/login/loading.tsx, app/(public)/signup/loading.tsx 추가**
  - 실제 폼 레이아웃을 모방하는 Skeleton 폴백. `components/ui/skeleton.tsx`의 `Skeleton` 컴포넌트 재사용
  - `SakuraRain` 등 무거운 클라이언트 컴포넌트는 폴백에서 제외해 초기 페인트 비용 최소화
- **app/(public)/login/error.tsx, app/(public)/signup/error.tsx 추가**
  - `"use client"` + `{ error, reset }` props의 세그먼트 Error Boundary
  - `useEffect`로 `console.error` 로깅 → 프로덕션 관측 가능성 확보
  - `error.message`는 노출하지 않고 사용자 친화 메시지 + `error.digest`만 표시
  - `reset()` 버튼 + 복귀 링크(홈/로그인) 제공
- **.claude/rules/page-patterns.md 규칙 보강**
  - `loading.tsx`: `Skeleton` 재사용, 무거운 클라이언트 컴포넌트 금지 규칙 명시
  - `error.tsx`: `useEffect` 로깅, `error.message` 미노출, 형제 `layout.tsx` 에러 미포착 제약 등 명시
  - 파일 레벨(`loading.tsx`) vs 컴포넌트 레벨(`<Suspense>`) 선택 가이드 신설
  - `notFound()` vs `error.tsx` 우선순위 명시
  - 규칙 리스트에 항목 추가 (5~11번)

## 리뷰 포인트
- base 브랜치가 `refactor/auth-form-rhf-zod`입니다 (해당 브랜치가 아직 머지되지 않아 `main`이 아닌 상위 리팩터 브랜치로 PR).
- 로그인/회원가입 페이지는 현재 `searchParams`만 await해서 데이터 패칭 부하가 작습니다. 그래서 **페이지 내부에 fine-grained `<Suspense>`는 추가하지 않고** 파일 레벨 `loading.tsx`만 두었습니다 — 규칙 문서의 "판단 기준" 섹션과 동일한 논리.
- 후속 작업으로 `(member)`, `(admin)`, `(super-admin)` 라우트 그룹에도 동일 패턴 확장 예정.

## 검증
- [x] `npx tsc --noEmit` 통과
- [ ] 로그인 페이지 네비게이션 시 스켈레톤 노출 확인
- [ ] 회원가입 페이지 네비게이션 시 스켈레톤 노출 확인
- [ ] Server Action에서 의도적으로 throw해 `error.tsx` 폴백 + `reset()` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)