### PR TITLE
perf(dashboard): 대시보드 데이터·이미지 로딩 경량화 및 규칙 정합

### DIFF
--- a/components/dashboard-v2.tsx
+++ b/components/dashboard-v2.tsx
@@ -12,6 +12,7 @@ import { SakuraRain } from "@/components/sakura-rain";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/cn";
+import { useDashboardCandidateSignedImages } from "@/hooks/useDashboardCandidateSignedImages";
 import { canEditCandidates } from "@/lib/role-utils";
 import { getOutcomeDotClass } from "@/lib/status-ui";
 import type { AppRole, Candidate, Membership, TimelineEvent } from "@/lib/types";
@@ -213,11 +214,13 @@ function TimelinePanel({
 /* ─── Main Dashboard ─── */
 
 export function DashboardV2({
-  candidates,
+  candidates: candidatesFromServer,
   timelineEvents,
   membership,
   initialView = "flow",
 }: DashboardV2Props) {
+  const candidates = useDashboardCandidateSignedImages(candidatesFromServer);
+
   const [view, setView] = useState<ViewMode>(initialView);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [search, setSearch] = useState("");

--- a/components/manager-dashboard.tsx
+++ b/components/manager-dashboard.tsx
@@ -3,6 +3,7 @@
 import { DashboardStatBar } from "@/components/dashboard-stat-bar";
 import { DashboardWorkspace } from "@/components/dashboard-workspace";
 import { SakuraRain } from "@/components/sakura-rain";
+import { useDashboardCandidateSignedImages } from "@/hooks/useDashboardCandidateSignedImages";
 import { DashboardViewMode } from "@/lib/types";
 import type { Candidate, Membership, TimelineEvent } from "@/lib/types";
 
@@ -14,11 +15,13 @@ type ManagerDashboardProps = {
 };
 
 export function ManagerDashboard({
-  candidates,
+  candidates: candidatesFromServer,
   timelineEvents,
   membership,
   initialView = DashboardViewMode.FLOW,
 }: ManagerDashboardProps) {
+  const candidates = useDashboardCandidateSignedImages(candidatesFromServer);
+
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-gradient-to-br from-rose-50 to-orange-50/50 text-slate-800">
       <SakuraRain petalCount={62} />

--- a/hooks/useDashboardCandidateSignedImages.ts
+++ b/hooks/useDashboardCandidateSignedImages.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { resolveDashboardCandidateImagePaths } from "@/lib/candidate-image-actions";
+import { isDirectImageUrl } from "@/lib/image-url-utils";
+import type { Candidate } from "@/lib/types";
+
+/**
+ * 대시보드: 서버는 Storage path만 내려주고, 서명은 Server Action으로만 수행합니다.
+ */
+export function useDashboardCandidateSignedImages(candidates: Candidate[]): Candidate[] {
+  const [pathToSigned, setPathToSigned] = useState<Record<string, string | null>>({});
+
+  const storagePathsKey = useMemo(() => {
+    const set = new Set<string>();
+    for (const candidate of candidates) {
+      const value = candidate.image_url?.trim();
+      if (value && !isDirectImageUrl(value)) set.add(value);
+    }
+    return [...set].sort().join("\n");
+  }, [candidates]);
+
+  useEffect(() => {
+    if (!storagePathsKey) {
+      setPathToSigned({});
+      return;
+    }
+
+    const paths = storagePathsKey.split("\n").filter(Boolean);
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const record = await resolveDashboardCandidateImagePaths(paths);
+        if (!cancelled) setPathToSigned(record);
+      } catch {
+        if (!cancelled) {
+          setPathToSigned(Object.fromEntries(paths.map((path) => [path, null] as const)));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [storagePathsKey]);
+
+  return useMemo(() => {
+    return candidates.map((candidate) => {
+      const raw = candidate.image_url?.trim() ?? null;
+      if (!raw) return candidate;
+      if (isDirectImageUrl(raw)) return candidate;
+      if (!(raw in pathToSigned)) return candidate;
+      return { ...candidate, image_url: pathToSigned[raw] };
+    });
+  }, [candidates, pathToSigned]);
+}

--- a/lib/candidate-image-actions.ts
+++ b/lib/candidate-image-actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { isDirectImageUrl } from "@/lib/image-url-utils";
 import {
   CANDIDATE_PHOTOS_BUCKET,
   CANDIDATE_PHOTOS_SIGNED_URL_TTL_SECONDS,
@@ -7,13 +8,39 @@ import {
 } from "@/lib/storage-signed-urls";
 import { createClient } from "@/lib/supabase/server";
 
-function isDirectImageUrl(value: string | null | undefined) {
-  return Boolean(
-    value &&
-      (value.startsWith("/") ||
-        value.startsWith("http://") ||
-        value.startsWith("https://")),
+const DASHBOARD_IMAGE_PATHS_MAX = 500;
+
+/**
+ * 대시보드용: Storage path 목록을 서버 세션으로 배치 서명합니다.
+ * (클라이언트에서 Supabase 호출 금지 규칙 — `lib/*-actions.ts`에서만 Storage 접근)
+ */
+export async function resolveDashboardCandidateImagePaths(
+  paths: string[],
+): Promise<Record<string, string | null>> {
+  const unique = [
+    ...new Set(
+      paths
+        .filter((path): path is string => typeof path === "string" && path.trim().length > 0)
+        .map((path) => path.trim())
+        .filter((path) => !isDirectImageUrl(path)),
+    ),
+  ].slice(0, DASHBOARD_IMAGE_PATHS_MAX);
+
+  if (!unique.length) return {};
+
+  const supabase = await createClient();
+  if (!supabase) {
+    return Object.fromEntries(unique.map((path) => [path, null] as const));
+  }
+
+  const signedByPath = await createSignedUrlMapForStoragePaths(
+    supabase,
+    CANDIDATE_PHOTOS_BUCKET,
+    unique,
+    CANDIDATE_PHOTOS_SIGNED_URL_TTL_SECONDS,
   );
+
+  return Object.fromEntries(unique.map((path) => [path, signedByPath.get(path) ?? null] as const));
 }
 
 /**

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -4,6 +4,7 @@ import {
   TAG_DASHBOARD_CANDIDATES,
   TAG_DASHBOARD_TIMELINE,
 } from "@/lib/cache-tags";
+import { isDirectImageUrl } from "@/lib/image-url-utils";
 import { unstable_cache } from "next/cache";
 import { mockCandidates, mockMatchRecords, mockMemberships } from "@/lib/mock-data";
 import { dashboardPreviewMatchRecords } from "@/lib/preview-scene";
@@ -91,15 +92,6 @@ function normalizeGender(value: string | null | undefined) {
 function normalizeHeightText(value: unknown) {
   const text = String(value ?? "").trim();
   return text || "모름";
-}
-
-function isDirectImageUrl(value: string | null | undefined) {
-  return Boolean(
-    value &&
-      (value.startsWith("/") ||
-        value.startsWith("http://") ||
-        value.startsWith("https://")),
-  );
 }
 
 async function resolveCandidateImage(
@@ -347,26 +339,13 @@ async function loadDashboardCandidatesUncached(): Promise<Candidate[]> {
   }
 
   const mapped = data.map((row) => mapDashboardCandidate(row));
-  const signedMap = await resolveSignedImageMap(
-    supabase,
-    mapped.map((c) => c.image_url),
-  );
-  const resolved = mapped.map((candidate) => ({
-    ...candidate,
-    image_url: candidate.image_url
-      ? isDirectImageUrl(candidate.image_url)
-        ? candidate.image_url
-        : signedMap.get(candidate.image_url) ?? null
-      : null,
-  }));
-
-  return mergeCandidates(resolved, mockCandidates);
+  return mergeCandidates(mapped, mockCandidates);
 }
 
 export async function getDashboardCandidates(): Promise<Candidate[]> {
   return unstable_cache(loadDashboardCandidatesUncached, ["cupid-dashboard-candidates-data"], {
     tags: [TAG_DASHBOARD_CANDIDATES],
-    revalidate: 45,
+    revalidate: 90,
   })();
 }
 
@@ -552,21 +531,13 @@ async function loadDashboardTimelineDataUncached(): Promise<{
     };
   }
 
-  const [countResult, recordsResult] = await Promise.all([
-    supabase
-      .from("cupid_match_records")
-      .select("id", { count: "exact", head: true }),
-    supabase
-      .from("cupid_match_records")
-      .select(
-        "id, candidate_id, counterpart_label, counterpart_candidate_id, matchmaker_name, outcome, summary, happened_on",
-      )
-      .order("happened_on", { ascending: false })
-      .limit(DASHBOARD_TIMELINE_FETCH_LIMIT),
-  ]);
-
-  const { count, error: countError } = countResult;
-  const { data, error } = recordsResult;
+  const { data, error } = await supabase
+    .from("cupid_match_records")
+    .select(
+      "id, candidate_id, counterpart_label, counterpart_candidate_id, matchmaker_name, outcome, summary, happened_on",
+    )
+    .order("happened_on", { ascending: false })
+    .limit(DASHBOARD_TIMELINE_FETCH_LIMIT);
 
   if (error || !data) {
     return {
@@ -579,10 +550,7 @@ async function loadDashboardTimelineDataUncached(): Promise<{
 
   return {
     records: mergedRecords,
-    totalCount:
-      countError || typeof count !== "number"
-        ? mergedRecords.length
-        : Math.max(count, mergedRecords.length),
+    totalCount: mergedRecords.length,
   };
 }
 
@@ -592,7 +560,7 @@ export async function getDashboardTimelineData(): Promise<{
 }> {
   return unstable_cache(loadDashboardTimelineDataUncached, ["cupid-dashboard-timeline-data"], {
     tags: [TAG_DASHBOARD_TIMELINE],
-    revalidate: 45,
+    revalidate: 90,
   })();
 }
 

--- a/lib/image-url-utils.ts
+++ b/lib/image-url-utils.ts
@@ -1,0 +1,9 @@
+/** Storage path가 아니라 이미 브라우저에서 쓸 수 있는 URL인지 */
+export function isDirectImageUrl(value: string | null | undefined) {
+  return Boolean(
+    value &&
+      (value.startsWith("/") ||
+        value.startsWith("http://") ||
+        value.startsWith("https://")),
+  );
+}


### PR DESCRIPTION
## 요약

대시보드 첫 로딩 시 서버에서 하던 불필요한 DB/Storage 작업을 줄이고, 프로필 썸네일 서명은 Server Action으로만 처리하도록 바꿨습니다. 

.claude의 클라이언트 Supabase 직접 호출 금지에 맞췄습니다.

## 변경 사항
### 데이터·캐시
- 타임라인용 전체 건수 count 헤드 쿼리 제거 — UI에서 totalCount를 쓰지 않아 캐시 미스마다 PostgREST 왕복 1회 감소.
- getDashboardCandidates / getDashboardTimelineData의 unstable_cache revalidate를 45초 → 90초로 조정 (태그 무효화 흐름은 동일).

### 대시보드 후보 이미지
- loadDashboardCandidatesUncached에서 Storage signed URL 발급 제거 — RSC 단계는 DB에서 path만 내려보냄.
- resolveDashboardCandidateImagePaths (lib/candidate-image-actions.ts) — path 배열을 서버 세션으로 배치 서명, 최대 500 path 제한·직링크 URL 필터.
- useDashboardCandidateSignedImages — 위 Server Action만 호출; 클라이언트에서는 Supabase 클라이언트 미사용.
- ManagerDashboard, **DashboardV2**에서 서버에서 받은 candidates를 훅으로 감싸 서명 반영.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized candidate image loading and caching strategy
  * Increased dashboard data refresh intervals for improved efficiency

* **Improvements**
  * Enhanced candidate image display with secured URL handling
  * Refined image resolution logic for better reliability across dashboard components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->