### PR TITLE
fix: 보기 전용 권한 안내를 뷰 토글 옆으로 이동

### DIFF
--- a/app/(member)/dashboard/_components/dashboard-content.tsx
+++ b/app/(member)/dashboard/_components/dashboard-content.tsx
@@ -5,7 +5,6 @@ import {
   type DashboardBoardCandidate,
 } from "./dashboard-flow-board";
 import { DashboardInventoryView } from "./dashboard-inventory-view";
-import { canEditCandidates } from "@/lib/role-utils";
 import { DashboardViewMode } from "@/lib/types";
 import type { AppRole, Candidate, TimelineEvent } from "@/lib/types";
 
@@ -46,11 +45,6 @@ export function DashboardContent({
         />
       ) : null}
 
-      {!canEditCandidates(role) ? (
-        <div className="rounded-[24px] border border-white/60 bg-white/70 px-5 py-4 text-sm text-slate-600 shadow-[0_8px_30px_rgb(244,114,182,0.08)] backdrop-blur-md">
-          현재 권한은 보기 전용입니다. 상세 이동과 상태 변경은 어드민 이상 권한에서 가능합니다.
-        </div>
-      ) : null}
     </>
   );
 }

--- a/app/(member)/dashboard/_components/dashboard-workspace.tsx
+++ b/app/(member)/dashboard/_components/dashboard-workspace.tsx
@@ -7,6 +7,7 @@ import { DashboardContent } from "./dashboard-content";
 import { DashboardStatBar } from "./dashboard-stat-bar";
 import { DashboardToolbar } from "./dashboard-toolbar";
 import { DashboardViewToggle } from "./dashboard-view-toggle";
+import { canEditCandidates } from "@/lib/role-utils";
 import { DashboardViewMode } from "@/lib/types";
 import type { AppRole, Candidate, TimelineEvent } from "@/lib/types";
 
@@ -136,7 +137,12 @@ export function DashboardWorkspace({
         </div>
       </div>
 
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between gap-3">
+        {!canEditCandidates(role) ? (
+          <div className="rounded-full border border-white/60 bg-white/70 px-4 py-2 text-sm text-slate-600 shadow-sm backdrop-blur-md">
+            현재 권한은 보기 전용입니다. 상세 이동과 상태 변경은 어드민 이상 권한에서 가능합니다.
+          </div>
+        ) : <div />}
         <DashboardViewToggle view={view} onViewChange={handleViewChange} />
       </div>
 


### PR DESCRIPTION
## Summary

- 하단에서 잘리던 보기 전용 권한 안내 배너를 뷰 토글 스위치 왼쪽으로 이동
- `dashboard-content.tsx`에서 중복 배너 제거

## Test plan

- [ ] viewer 권한으로 대시보드 접속 시 뷰 토글 옆에 안내 문구 표시 확인
- [ ] admin 이상 권한에서는 안내 문구 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dashboard toolbar layout and reorganized the read-only notice positioning for improved UI arrangement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->