### PR TITLE
Tune image upload, transforms, and caching

### DIFF
--- a/components/photo-upload-field.tsx
+++ b/components/photo-upload-field.tsx
@@ -6,13 +6,13 @@ import { createClient } from "@/lib/supabase/client";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { cn } from "@/lib/cn";
 
 const CANDIDATE_PHOTOS_BUCKET = "sogaeting";
-const MAX_TOTAL_UPLOAD_BYTES = 45 * 1024 * 1024;
-const MAX_SINGLE_UPLOAD_BYTES = 10 * 1024 * 1024;
-const MAX_IMAGE_DIMENSION = 1800;
-const MIN_COMPRESSION_TARGET_BYTES = 1.5 * 1024 * 1024;
+const MAX_TOTAL_UPLOAD_BYTES = 24 * 1024 * 1024;
+const MAX_SINGLE_UPLOAD_BYTES = 6 * 1024 * 1024;
+const MAX_IMAGE_DIMENSION = 1280;
+const MIN_COMPRESSION_TARGET_BYTES = 512 * 1024;
+const STORAGE_CACHE_CONTROL_SECONDS = 60 * 60 * 24 * 30;
 const ALLOWED_UPLOAD_TYPES = new Set([
   "image/jpeg",
   "image/png",
@@ -64,6 +64,13 @@ function safeFileName(fileName: string) {
   const normalizedExt = ext.replace(/[^.a-z0-9]/g, "");
 
   return `${normalizedBase}${normalizedExt || ".jpg"}`;
+}
+
+function getOptimizedFileName(fileName: string) {
+  const trimmed = fileName.trim();
+  const dotIndex = trimmed.lastIndexOf(".");
+  const base = dotIndex >= 0 ? trimmed.slice(0, dotIndex) : trimmed;
+  return `${base || "photo"}.webp`;
 }
 
 async function loadImage(file: File) {
@@ -118,7 +125,7 @@ async function optimizeImageFile(file: File) {
     context.drawImage(image, 0, 0, targetWidth, targetHeight);
 
     const optimizedBlob = await new Promise<Blob | null>((resolve) => {
-      canvas.toBlob(resolve, "image/webp", 0.82);
+      canvas.toBlob(resolve, "image/webp", 0.76);
     });
 
     if (!optimizedBlob || optimizedBlob.size >= file.size) {
@@ -128,8 +135,7 @@ async function optimizeImageFile(file: File) {
       };
     }
 
-    const optimizedName = file.name.replace(/\.[^.]+$/, "") || "photo";
-    const optimizedFile = new File([optimizedBlob], `${optimizedName}.webp`, {
+    const optimizedFile = new File([optimizedBlob], getOptimizedFileName(file.name), {
       type: "image/webp",
       lastModified: file.lastModified,
     });
@@ -146,14 +152,6 @@ async function optimizeImageFile(file: File) {
   }
 }
 
-function isMobileUploadFallback() {
-  if (typeof navigator === "undefined") {
-    return false;
-  }
-
-  return /android|iphone|ipad|ipod|mobile/i.test(navigator.userAgent);
-}
-
 export function PhotoUploadField({
   storageFolderId,
   inputName = "uploadedPhotoPaths",
@@ -163,7 +161,6 @@ export function PhotoUploadField({
   const [previews, setPreviews] = useState<UploadedPreviewItem[]>([]);
   const [message, setMessage] = useState("여러 장을 첨부하면 첫 사진이 대표 사진이 됩니다.");
   const [isUploading, setIsUploading] = useState(false);
-  const [nativeMode, setNativeMode] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -209,35 +206,24 @@ export function PhotoUploadField({
     setIsUploading(true);
 
     try {
-      const useNativeMode = nativeMode || isMobileUploadFallback();
-
-      if (useNativeMode && !nativeMode) {
-        setNativeMode(true);
-      }
-
       for (const file of selectedFiles) {
         if (!ALLOWED_UPLOAD_TYPES.has(file.type)) {
           throw new Error("JPG, PNG, WEBP, HEIC, HEIF 형식만 업로드할 수 있습니다.");
         }
 
         if (file.size > MAX_SINGLE_UPLOAD_BYTES) {
-          throw new Error("사진 한 장은 10MB 이하만 업로드할 수 있습니다.");
+          throw new Error("사진 한 장은 6MB 이하만 업로드할 수 있습니다.");
         }
       }
 
-      const processedFiles: ProcessedFile[] = useNativeMode
-        ? selectedFiles.map((file) => ({
-            file,
-            helperText: `${formatBytes(file.size)} · 원본 유지`,
-          }))
-        : await Promise.all(selectedFiles.map(optimizeImageFile));
+      const processedFiles: ProcessedFile[] = await Promise.all(selectedFiles.map(optimizeImageFile));
 
       const totalBytes =
         previews.reduce((sum, item) => sum + item.size, 0) +
         processedFiles.reduce((sum, item) => sum + item.file.size, 0);
 
       if (totalBytes > MAX_TOTAL_UPLOAD_BYTES) {
-        throw new Error("사진 총 용량은 45MB 이하로 맞춰주세요.");
+        throw new Error("사진 총 용량은 24MB 이하로 맞춰주세요.");
       }
 
       const uploadedItems: UploadedPreviewItem[] = [];
@@ -248,6 +234,7 @@ export function PhotoUploadField({
           const { error } = await supabase.storage
             .from(CANDIDATE_PHOTOS_BUCKET)
             .upload(path, item.file, {
+              cacheControl: String(STORAGE_CACHE_CONTROL_SECONDS),
               contentType: item.file.type || "application/octet-stream",
               upsert: false,
             });
@@ -279,9 +266,7 @@ export function PhotoUploadField({
 
       setPreviews((current) => [...current, ...uploadedItems]);
 
-      if (nativeMode || useNativeMode) {
-        setMessage(`모바일 원본 업로드 완료 · 총 ${previews.length + uploadedItems.length}장`);
-      } else if (processedFiles.some((item) => item.file.type === "image/webp")) {
+      if (processedFiles.some((item) => item.helperText.includes("->"))) {
         setMessage(`자동 최적화 후 업로드 완료 · 총 ${previews.length + uploadedItems.length}장`);
       } else {
         setMessage(`업로드 완료 · 총 ${previews.length + uploadedItems.length}장`);
@@ -308,8 +293,8 @@ export function PhotoUploadField({
           <Badge variant="secondary">[선택]</Badge>
         </span>
         <span className="text-sm leading-7 text-muted-foreground">
-          선택 사항입니다. 사진은 브라우저에서 바로 안전하게 업로드됩니다. 모바일에서는 원본
-          업로드를 우선 사용합니다.
+          선택 사항입니다. 사진은 업로드 전에 브라우저에서 최대 1280px로 줄이고, 가능한 경우
+          WEBP로 압축합니다.
         </span>
         <span className="inline-flex min-h-11 w-full items-center justify-center rounded-full border border-border bg-card px-4 text-sm font-semibold text-secondary-foreground sm:w-fit">
           사진 선택하기

--- a/lib/candidate-image-actions.ts
+++ b/lib/candidate-image-actions.ts
@@ -12,12 +12,12 @@ import { createClient } from "@/lib/supabase/server";
 
 const DASHBOARD_IMAGE_PATHS_MAX = 500;
 const DASHBOARD_PROFILE_IMAGE_TRANSFORM = {
-  width: 240,
-  height: 240,
-  quality: 54,
+  width: 160,
+  height: 160,
+  quality: 40,
   resize: "cover" as const,
 };
-const PROFILE_IMAGE_CACHE_SECONDS = 60 * 30;
+const PROFILE_IMAGE_CACHE_SECONDS = 60 * 60 * 6;
 
 /**
  * 대시보드용: Storage path 목록을 서버 세션으로 배치 서명합니다.

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -23,42 +23,44 @@ import type {
 
 const DASHBOARD_TIMELINE_FETCH_LIMIT = 40;
 const TIMELINE_PAGE_SIZE = 40;
+const DASHBOARD_CANDIDATES_CACHE_SECONDS = 60 * 15;
+const PROFILE_CONTENT_CACHE_SECONDS = 60 * 60 * 6;
 const IMAGE_TRANSFORMS = {
   thumb: {
-    height: 240,
-    quality: 52,
+    height: 160,
+    quality: 40,
     resize: "cover" as const,
-    width: 240,
+    width: 160,
   },
   card: {
-    height: 560,
-    quality: 60,
+    height: 480,
+    quality: 48,
     resize: "cover" as const,
-    width: 420,
+    width: 360,
   },
   detail: {
-    height: 1280,
-    quality: 68,
+    height: 960,
+    quality: 58,
     resize: "cover" as const,
-    width: 960,
+    width: 720,
   },
   gallery: {
-    height: 720,
-    quality: 60,
-    resize: "cover" as const,
-    width: 560,
-  },
-  galleryThumb: {
-    height: 140,
-    quality: 44,
-    resize: "cover" as const,
-    width: 112,
-  },
-  editorThumb: {
-    height: 400,
+    height: 640,
     quality: 52,
     resize: "cover" as const,
-    width: 320,
+    width: 480,
+  },
+  galleryThumb: {
+    height: 120,
+    quality: 36,
+    resize: "cover" as const,
+    width: 96,
+  },
+  editorThumb: {
+    height: 320,
+    quality: 42,
+    resize: "cover" as const,
+    width: 240,
   },
 };
 
@@ -350,7 +352,7 @@ async function loadDashboardCandidatesUncached(): Promise<Candidate[]> {
 export async function getDashboardCandidates(): Promise<Candidate[]> {
   return unstable_cache(loadDashboardCandidatesUncached, ["cupid-dashboard-candidates-data"], {
     tags: [TAG_DASHBOARD_CANDIDATES],
-    revalidate: 90,
+    revalidate: DASHBOARD_CANDIDATES_CACHE_SECONDS,
   })();
 }
 
@@ -424,7 +426,7 @@ async function loadCandidateByIdUncached(id: string) {
 export async function getCandidateById(id: string) {
   return unstable_cache(async () => loadCandidateByIdUncached(id), ["cupid-candidate-detail", id], {
     tags: [candidateProfileTag(id)],
-    revalidate: 45,
+    revalidate: PROFILE_CONTENT_CACHE_SECONDS,
   })();
 }
 
@@ -518,7 +520,7 @@ export async function getMatchRecords(candidateId?: string) {
     return unstable_cache(
       async () => loadMatchRecordsForCandidateUncached(candidateId),
       ["cupid-match-records-candidate", candidateId],
-      { tags: [candidateProfileTag(candidateId)], revalidate: 45 },
+      { tags: [candidateProfileTag(candidateId)], revalidate: PROFILE_CONTENT_CACHE_SECONDS },
     )();
   }
   return loadMatchRecordsAllUncached();
@@ -810,7 +812,7 @@ export async function getCandidatePhotos(candidateId: string) {
   return unstable_cache(
     async () => loadCandidatePhotosUncached(candidateId),
     ["cupid-candidate-photos", candidateId],
-    { tags: [candidateProfileTag(candidateId)], revalidate: 45 },
+    { tags: [candidateProfileTag(candidateId)], revalidate: PROFILE_CONTENT_CACHE_SECONDS },
   )();
 }
 
@@ -909,7 +911,7 @@ export async function getProfileGalleryImages(candidateId: string): Promise<Cand
   return unstable_cache(
     async () => loadProfileGalleryImagesUncached(candidateId),
     ["cupid-profile-gallery-images", candidateId],
-    { tags: [candidateProfileTag(candidateId)], revalidate: 45 },
+    { tags: [candidateProfileTag(candidateId)], revalidate: PROFILE_CONTENT_CACHE_SECONDS },
   )();
 }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
-    "clean": "rimraf .next tsconfig.tsbuildinfo"
+    "clean": "rimraf .next tsconfig.tsbuildinfo",
+    "storage:optimize-images": "node scripts/optimize-supabase-storage-images.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",


### PR DESCRIPTION
Reduce client upload sizes and image dimensions, enable WebP optimization and longer caching, and adjust server image transforms.

- Photo upload: lower limits (single 6MB, total 24MB), max dimension 1280, target compression 512KB, canvas WebP quality 0.76, generate .webp filenames, and add 30-day storage Cache-Control on upload. Removed mobile native-upload fallback and always run optimization. Update UI copy and error messages.
- Candidate images / data: reduce dashboard/profile transform dimensions and quality, increase profile cache duration to 6 hours and dashboard candidates cache to 15 minutes; replace hardcoded revalidate values with constants.
- package.json: add storage:optimize-images script.

These changes aim to reduce bandwidth and storage usage while improving cache behavior and frontend load performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed mobile-specific upload fallback behavior

* **Performance**
  * Reduced photo upload size constraints
  * Lowered required image resolution
  * Extended profile image cache duration
  * Enhanced image compression efficiency

* **New Features**
  * Added storage image optimization utility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->