### PR TITLE
google-social-login | add : google social login function

### DIFF
--- a/app/(public)/auth/callback/route.ts
+++ b/app/(public)/auth/callback/route.ts
@@ -6,17 +6,18 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
   const next = url.searchParams.get("next") ?? "/pending";
-  const response = NextResponse.redirect(new URL(next, url.origin));
 
   if (
     !code ||
     !process.env.NEXT_PUBLIC_SUPABASE_URL ||
     !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY
   ) {
-    return response;
+    return NextResponse.redirect(new URL(next, url.origin));
   }
 
   const cookieStore = await cookies();
+  const response = NextResponse.redirect(new URL(next, url.origin));
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY,
@@ -35,7 +36,35 @@ export async function GET(request: Request) {
     },
   );
 
-  await supabase.auth.exchangeCodeForSession(code);
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    return NextResponse.redirect(new URL("/login", url.origin));
+  }
+
+  // OAuth 로그인 후 멤버십 상태에 따라 목적지 결정
+  if (next === "/dashboard") {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (user) {
+      const { data: membership } = await supabase
+        .from("cupid_memberships")
+        .select("status")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (!membership || membership.status !== "approved") {
+        const redirectUrl = new URL("/pending", url.origin);
+        const pendingResponse = NextResponse.redirect(redirectUrl);
+        response.cookies.getAll().forEach((cookie) => {
+          pendingResponse.cookies.set(cookie.name, cookie.value);
+        });
+        return pendingResponse;
+      }
+    }
+  }
 
   return response;
 }

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { GoogleLoginButton } from "@/components/google-login-button";
 
 export function LoginForm() {
   const [isPending, startTransition] = useTransition();
@@ -86,6 +87,14 @@ export function LoginForm() {
             </Button>
           </FieldGroup>
         </form>
+
+        <div className="relative my-6 flex items-center">
+          <div className="flex-1 border-t border-border/40" />
+          <span className="px-3 text-xs text-muted-foreground">또는</span>
+          <div className="flex-1 border-t border-border/40" />
+        </div>
+
+        <GoogleLoginButton label="Google로 로그인" nextPath="/dashboard" />
 
         <div className="mt-6 text-center">
           <p className="text-sm text-muted-foreground">

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { GoogleLoginButton } from "@/components/google-login-button";
 
 export function SignupForm() {
   const [isPending, startTransition] = useTransition();
@@ -100,6 +101,14 @@ export function SignupForm() {
             </Button>
           </FieldGroup>
         </form>
+
+        <div className="relative my-6 flex items-center">
+          <div className="flex-1 border-t border-border/40" />
+          <span className="px-3 text-xs text-muted-foreground">또는</span>
+          <div className="flex-1 border-t border-border/40" />
+        </div>
+
+        <GoogleLoginButton label="Google로 가입하기" nextPath="/pending" />
 
         <div className="mt-6 text-center">
           <p className="text-sm text-muted-foreground">

--- a/server/actions/auth.ts
+++ b/server/actions/auth.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { loginSchema, signupSchema, type LoginInput, type SignupInput } from "@/lib/schemas/auth";
 
@@ -80,6 +81,27 @@ export async function signInWithPassword(input: LoginInput): Promise<ActionResul
   }
 
   redirect("/dashboard");
+}
+
+export async function signInWithGoogle(nextPath = "/dashboard") {
+  const supabase = await createClient();
+  if (!supabase) return { error: "Supabase 환경변수가 없습니다." };
+
+  const headerStore = await headers();
+  const origin = headerStore.get("origin") ?? process.env.NEXT_PUBLIC_APP_URL ?? "";
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "google",
+    options: {
+      redirectTo: `${origin}/auth/callback?next=${encodeURIComponent(nextPath)}`,
+      queryParams: { access_type: "offline", prompt: "consent" },
+    },
+  });
+
+  if (error) return { error: error.message };
+  if (data.url) redirect(data.url);
+
+  return { error: "OAuth URL을 생성할 수 없습니다." };
 }
 
 export async function signOut() {


### PR DESCRIPTION
Related to #19 


운영자가 아이디/비밀번호 외에 **Google 계정으로 로그인·가입**할 수 있도록 한다. 인증은 Supabase Auth의 Google Provider를 사용하고, 앱은 기존 `/auth/callback`에서 PKCE 코드를 세션으로 교환한 뒤 멤버십 상태에 따라 `/dashboard` 또는 `/pending`으로 보낸다. Google OAuth 클라이언트 ID/Secret은 **Supabase Dashboard > Authentication > Providers > Google**에 등록하고, 리다이렉트 URI는 `{SUPABASE_URL}/auth/v1/callback`을 사용한다.

## 서비스 영향범위

- Project Cupid 웹(Next.js App Router): `/login`, `/signup`, `/auth/callback`
- 배포 후 **Supabase에서 Google Provider 활성화**가 선행되어야 실제 로그인 동작함 (미설정 시 OAuth URL 생성 단계에서 실패 가능)

<img width="618" height="658" alt="스크린샷 2026-04-12 오후 6 55 13" src="https://github.com/user-attachments/assets/c8f9ff62-1c9f-41b3-a2d8-0e4dc621b5e3" />

@saechimdaeki 님 supabase 프로젝트가 뭔지 알려줄수있나요?
google cloud oath 에 supabase 콜백 주소 넣어야 함

이런식으로 .. 
https://<프로젝트>.supabase.co/auth/v1/callback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google authentication is now available for login and signup flows.
  * Users can authenticate and register using their Google account alongside email/password options.

* **Bug Fixes**
  * Added error handling for authentication failures with appropriate redirects.
  * Improved post-authentication routing based on account status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->