### PR TITLE
#39 refactor password

### DIFF
--- a/app/(member)/dashboard/_components/flow-board-active-lane.tsx
+++ b/app/(member)/dashboard/_components/flow-board-active-lane.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@/lib/cn";
 import type { AppRole } from "@/lib/types";
 import type { DashboardBoardCandidate } from "./dashboard-flow-board";
 import { FlowBoardCard } from "./flow-board-card";
@@ -55,19 +54,6 @@ export function FlowBoardActiveLaneContent({
 
   return (
     <div className="mt-4 flex min-h-0 flex-1 flex-col overflow-y-auto -mx-5 px-5 -mb-5 pb-5 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-rose-200/60">
-      <div className="grid grid-cols-2 gap-x-3">
-        <p
-          className={cn(
-            "mb-2 flex shrink-0 items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-400/80",
-          )}
-        >
-          <span>🤵</span> 남성
-        </p>
-        <p className="mb-2 flex shrink-0 items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-rose-400/80">
-          <span>👰</span> 여성
-        </p>
-      </div>
-
       <div className="grid min-w-0 gap-3">
         {rows.length ? (
           rows.map((row, index) => (

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { signInWithPassword } from "@/server/actions/auth";
 import { loginSchema, type LoginInput } from "@/lib/schemas/auth";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/password-input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
@@ -69,10 +70,9 @@ export function LoginForm() {
 
             <Field data-invalid={errors.password ? true : undefined}>
               <FieldLabel htmlFor="login-password">비밀번호</FieldLabel>
-              <Input
+              <PasswordInput
                 id="login-password"
                 className="h-12 rounded-xl border-border/50 bg-card/60"
-                type="password"
                 placeholder="비밀번호 입력"
                 autoComplete="current-password"
                 aria-invalid={errors.password ? true : undefined}

--- a/components/password-input.tsx
+++ b/components/password-input.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import type { ComponentProps } from "react";
+import { Eye, EyeOff } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type PasswordInputProps = ComponentProps<"input">;
+
+export function PasswordInput({ className, disabled, ...props }: PasswordInputProps) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input
+        className={cn("pr-12", className)}
+        disabled={disabled}
+        type={isVisible ? "text" : "password"}
+        {...props}
+      />
+      <Button
+        aria-label={isVisible ? "비밀번호 숨기기" : "비밀번호 보기"}
+        className="absolute right-1.5 top-1/2 size-9 -translate-y-1/2 rounded-lg text-muted-foreground hover:text-foreground"
+        disabled={disabled}
+        size="icon"
+        type="button"
+        variant="ghost"
+        onClick={() => setIsVisible((current) => !current)}
+      >
+        {isVisible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+      </Button>
+    </div>
+  );
+}

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { signUpWithPassword } from "@/server/actions/auth";
 import { signupSchema, type SignupInput } from "@/lib/schemas/auth";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/password-input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
@@ -83,10 +84,9 @@ export function SignupForm() {
 
             <Field data-invalid={errors.password ? true : undefined}>
               <FieldLabel htmlFor="signup-password">비밀번호</FieldLabel>
-              <Input
+              <PasswordInput
                 id="signup-password"
                 className="h-12 rounded-xl border-border/50 bg-card/60"
-                type="password"
                 placeholder="6자 이상"
                 autoComplete="new-password"
                 aria-invalid={errors.password ? true : undefined}


### PR DESCRIPTION
## 작업 내용

- 매칭 보드의 적극검토 영역에서 `남성 / 여성` 성별 라벨 헤더를 제거했습니다.
- 성별 라벨 때문에 한쪽 카드 레이아웃이 아래로 밀려 보이던 간격 문제를 개선했습니다.
- 로그인 화면 비밀번호 입력창에 보기/숨기기 토글 버튼을 추가했습니다.
- 회원가입 화면 비밀번호 입력창에도 동일한 보기/숨기기 토글 버튼을 추가했습니다.
- 로그인/회원가입에서 재사용할 수 있도록 공통 `PasswordInput` 컴포넌트를 추가했습니다.

## 변경 파일

- `app/(member)/dashboard/_components/flow-board-active-lane.tsx`
- `components/login-form.tsx`
- `components/signup-form.tsx`
- `components/password-input.tsx`

## 검증

- `npm run typecheck` 통과
- `/login` 페이지 200 OK 확인
- `/signup` 페이지 200 OK 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password visibility toggle to login and signup forms, allowing users to easily reveal or hide their password input with a single click for improved usability and control.

* **UI Changes**
  * Simplified dashboard flow board by removing the legend header display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->