### PR TITLE
refactor: 대시보드 스크롤 UX 개선 및 Supabase 이미지 서명 호출 절감

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "Bash(npm run:*)",
       "Bash(git add:*)",
       "Bash(git commit -m ':*)",
-      "Bash(npx tsc:*)"
+      "Bash(npx tsc:*)",
+      "Bash(grep -E \"\\\\.tsx$|^d\")",
+      "Bash(xargs ls *)"
     ]
   }
 }

--- a/app/(member)/dashboard/_components/dashboard-inventory-view.tsx
+++ b/app/(member)/dashboard/_components/dashboard-inventory-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { CandidateCard } from "@/components/candidate-card";
 import { DashboardTimelinePanel } from "./dashboard-timeline-panel";
 import { Button } from "@/components/ui/button";
@@ -19,20 +19,25 @@ export function DashboardInventoryView({
   timelineEvents,
   role,
 }: DashboardInventoryViewProps) {
-  const [visibleCount, setVisibleCount] = useState(INVENTORY_PAGE_SIZE);
+  const candidatesKey = useMemo(
+    () => candidates.map((candidate) => candidate.id).join("|"),
+    [candidates],
+  );
+  const [pagination, setPagination] = useState({
+    candidatesKey: "",
+    visibleCount: INVENTORY_PAGE_SIZE,
+  });
+  const visibleCount =
+    pagination.candidatesKey === candidatesKey ? pagination.visibleCount : INVENTORY_PAGE_SIZE;
   const visibleCandidates = useMemo(
     () => candidates.slice(0, visibleCount),
     [candidates, visibleCount],
   );
   const hasMore = visibleCandidates.length < candidates.length;
 
-  useEffect(() => {
-    setVisibleCount(INVENTORY_PAGE_SIZE);
-  }, [candidates]);
-
   return (
-    <section className="grid gap-6 xl:h-[calc(100dvh-22rem)] xl:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)]">
-      <div className="grid auto-rows-max gap-5 xl:overflow-y-auto xl:[&::-webkit-scrollbar]:w-1 xl:[&::-webkit-scrollbar-track]:bg-transparent xl:[&::-webkit-scrollbar-thumb]:rounded-full xl:[&::-webkit-scrollbar-thumb]:bg-rose-200/60">
+    <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)] xl:items-start">
+      <div className="grid auto-rows-max gap-5">
         {visibleCandidates.length ? (
           visibleCandidates.map((candidate) => (
             <CandidateCard key={candidate.id} candidate={candidate} role={role} />
@@ -49,7 +54,12 @@ export function DashboardInventoryView({
               type="button"
               variant="outline"
               className="rounded-full border-rose-200/80 bg-white/80 px-5"
-              onClick={() => setVisibleCount((count) => count + INVENTORY_PAGE_SIZE)}
+              onClick={() =>
+                setPagination({
+                  candidatesKey,
+                  visibleCount: visibleCount + INVENTORY_PAGE_SIZE,
+                })
+              }
             >
               후보 더 보기
             </Button>
@@ -60,7 +70,7 @@ export function DashboardInventoryView({
       <DashboardTimelinePanel
         events={timelineEvents}
         candidates={candidates}
-        className="xl:overflow-y-auto xl:[&::-webkit-scrollbar]:w-1 xl:[&::-webkit-scrollbar-track]:bg-transparent xl:[&::-webkit-scrollbar-thumb]:rounded-full xl:[&::-webkit-scrollbar-thumb]:bg-rose-200/60"
+        className="xl:sticky xl:top-[calc(4.25rem+1rem)] xl:max-h-[calc(100dvh-4.25rem-2rem)] xl:overflow-y-auto xl:[&::-webkit-scrollbar]:w-1 xl:[&::-webkit-scrollbar-track]:bg-transparent xl:[&::-webkit-scrollbar-thumb]:rounded-full xl:[&::-webkit-scrollbar-thumb]:bg-rose-200/60"
       />
     </section>
   );

--- a/app/(member)/dashboard/_components/dashboard-workspace.tsx
+++ b/app/(member)/dashboard/_components/dashboard-workspace.tsx
@@ -131,7 +131,7 @@ export function DashboardWorkspace({
   return (
     <>
       {/* Stat + Toolbar — 하나의 카드 */}
-      <div className="overflow-hidden rounded-2xl border border-white/60 bg-white/80 shadow-sm backdrop-blur-md">
+      <div className="overflow-hidden rounded-2xl border border-white/60 bg-white/80 shadow-sm backdrop-blur-md xl:sticky xl:top-[calc(4.25rem+0.75rem)] xl:z-20">
         <DashboardStatBar candidates={candidates} timelineEvents={timelineEvents} />
         <div className="border-t border-slate-100">
           <DashboardToolbar

--- a/app/(member)/dashboard/_components/flow-board-active-lane.tsx
+++ b/app/(member)/dashboard/_components/flow-board-active-lane.tsx
@@ -53,51 +53,49 @@ export function FlowBoardActiveLaneContent({
   );
 
   return (
-    <div className="mt-4 flex min-h-0 flex-1 flex-col overflow-y-auto -mx-5 px-5 -mb-5 pb-5 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-rose-200/60">
-      <div className="grid min-w-0 gap-3">
-        {rows.length ? (
-          rows.map((row, index) => (
-            <div key={`active-row-${index}`} className="grid grid-cols-2 items-stretch gap-3">
-              <div className="min-w-0">
-                {row.male ? (
-                  <FlowBoardCard
-                    key={row.male.id}
-                    candidate={row.male}
-                    candidateDirectory={candidateDirectory}
-                    role={role}
-                    canOperate={canOperate}
-                    pendingCandidateIds={pendingCandidateIds}
-                    fillRowHeight
-                  />
-                ) : (
-                  emptySlot("남")
-                )}
-              </div>
-
-              <div className="min-w-0">
-                {row.female ? (
-                  <FlowBoardCard
-                    key={row.female.id}
-                    candidate={row.female}
-                    candidateDirectory={candidateDirectory}
-                    role={role}
-                    canOperate={canOperate}
-                    pendingCandidateIds={pendingCandidateIds}
-                    fillRowHeight
-                  />
-                ) : (
-                  emptySlot("여")
-                )}
-              </div>
+    <div className="mt-4 grid min-w-0 gap-3">
+      {rows.length ? (
+        rows.map((row, index) => (
+          <div key={`active-row-${index}`} className="grid grid-cols-2 items-stretch gap-3">
+            <div className="min-w-0">
+              {row.male ? (
+                <FlowBoardCard
+                  key={row.male.id}
+                  candidate={row.male}
+                  candidateDirectory={candidateDirectory}
+                  role={role}
+                  canOperate={canOperate}
+                  pendingCandidateIds={pendingCandidateIds}
+                  fillRowHeight
+                />
+              ) : (
+                emptySlot("남")
+              )}
             </div>
-          ))
-        ) : (
-          <div className="grid grid-cols-2 gap-3">
-            <div className="min-w-0">{emptySlot("남")}</div>
-            <div className="min-w-0">{emptySlot("여")}</div>
+
+            <div className="min-w-0">
+              {row.female ? (
+                <FlowBoardCard
+                  key={row.female.id}
+                  candidate={row.female}
+                  candidateDirectory={candidateDirectory}
+                  role={role}
+                  canOperate={canOperate}
+                  pendingCandidateIds={pendingCandidateIds}
+                  fillRowHeight
+                />
+              ) : (
+                emptySlot("여")
+              )}
+            </div>
           </div>
-        )}
-      </div>
+        ))
+      ) : (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="min-w-0">{emptySlot("남")}</div>
+          <div className="min-w-0">{emptySlot("여")}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(member)/dashboard/_components/flow-board-card.tsx
+++ b/app/(member)/dashboard/_components/flow-board-card.tsx
@@ -176,6 +176,7 @@ export function FlowBoardCard({
   const inner = canAccessCandidateDetail(role) ? (
     <Link
       href={`/profiles/${candidate.id}`}
+      prefetch={false}
       className={cn("block", fillRowHeight && "flex h-full flex-col")}
     >
       {body}

--- a/app/(member)/dashboard/_components/flow-board-desktop-view.tsx
+++ b/app/(member)/dashboard/_components/flow-board-desktop-view.tsx
@@ -27,7 +27,7 @@ export function FlowBoardDesktopView({
   candidateDirectory,
 }: FlowBoardDesktopViewProps) {
   return (
-    <div className="hidden gap-5 lg:grid lg:grid-cols-3 lg:h-[calc(100dvh-22rem)] xl:gap-6">
+    <div className="hidden gap-5 lg:grid lg:grid-cols-3 xl:gap-6">
       {PRIMARY_LANES.map((lane) => (
         <FlowBoardLane
           key={lane.key}

--- a/app/(member)/dashboard/_components/flow-board-lane.tsx
+++ b/app/(member)/dashboard/_components/flow-board-lane.tsx
@@ -79,7 +79,7 @@ export function FlowBoardLane({
       id={status}
       isDropTarget={isDropTarget}
       className={cn(
-        "flex min-h-0 flex-col rounded-[26px] border border-white/70 p-5 shadow-[0_10px_40px_rgb(244,114,182,0.08)] backdrop-blur-sm",
+        "flex min-h-[14rem] flex-col rounded-[26px] border border-white/70 p-5 shadow-[0_10px_40px_rgb(244,114,182,0.08)] backdrop-blur-sm",
         getLaneSurfaceClass(status),
       )}
     >

--- a/app/(member)/dashboard/_components/flow-board-pair-card.tsx
+++ b/app/(member)/dashboard/_components/flow-board-pair-card.tsx
@@ -139,7 +139,7 @@ function FlowBoardPairHalf({
 
   if (candidate && canAccessCandidateDetail(role)) {
     return (
-      <Link href={`/profiles/${candidate.id}`} className="block h-full">
+      <Link href={`/profiles/${candidate.id}`} prefetch={false} className="block h-full">
         {content}
       </Link>
     );

--- a/app/(member)/dashboard/_components/flow-board-paired-lane.tsx
+++ b/app/(member)/dashboard/_components/flow-board-paired-lane.tsx
@@ -74,7 +74,7 @@ export function FlowBoardPairedLaneContent({
   const pairedRows = buildPairedLaneRows(items);
 
   return (
-    <div className="mt-4 flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto -mx-5 px-5 -mb-5 pb-5 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-rose-200/60">
+    <div className="mt-4 flex flex-col gap-3">
       {pairedRows.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-rose-200/60 bg-white/50 px-3 py-8 text-center text-xs text-slate-400">
           매칭된 후보가 없습니다

--- a/app/(member)/dashboard/_components/manager-dashboard.tsx
+++ b/app/(member)/dashboard/_components/manager-dashboard.tsx
@@ -19,7 +19,7 @@ export function ManagerDashboard({
   initialView = DashboardViewMode.FLOW,
 }: ManagerDashboardProps) {
   return (
-    <div className="relative min-h-dvh bg-gradient-to-br from-rose-50 to-orange-50/50 text-slate-800 xl:h-dvh xl:overflow-hidden">
+    <div className="relative min-h-dvh bg-gradient-to-br from-rose-50 to-orange-50/50 text-slate-800">
       <SakuraRain petalCount={62} />
       <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(ellipse_at_22%_0%,rgba(255,228,230,0.6),transparent_46%),radial-gradient(ellipse_at_82%_28%,rgba(255,237,213,0.48),transparent_42%),radial-gradient(circle_at_50%_100%,rgba(255,241,242,0.52),transparent_55%)]" />
 

--- a/components/candidate-card.tsx
+++ b/components/candidate-card.tsx
@@ -118,7 +118,7 @@ export function CandidateCard({ candidate, role = "viewer" }: CandidateCardProps
   }
 
   return (
-    <Link href={`/profiles/${candidate.id}`} className="block">
+    <Link href={`/profiles/${candidate.id}`} prefetch={false} className="block">
       {body}
     </Link>
   );

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -23,7 +23,8 @@ import type {
 
 const DASHBOARD_TIMELINE_FETCH_LIMIT = 40;
 const TIMELINE_PAGE_SIZE = 40;
-const DASHBOARD_CANDIDATES_CACHE_SECONDS = 60 * 15;
+const SIGNED_IMAGE_URL_CACHE_SECONDS = 60 * 60 * 22;
+const DASHBOARD_CANDIDATES_CACHE_SECONDS = SIGNED_IMAGE_URL_CACHE_SECONDS;
 const PROFILE_CONTENT_CACHE_SECONDS = 60 * 60 * 6;
 const IMAGE_TRANSFORMS = {
   thumb: {
@@ -135,6 +136,22 @@ async function resolveCandidateImage(
   return data.signedUrl;
 }
 
+async function resolveCandidateImageCached(
+  supabase: NonNullable<Awaited<ReturnType<typeof createClient>>>,
+  value: string | null,
+  variant: keyof typeof IMAGE_TRANSFORMS = "card",
+) {
+  if (!value || isDirectImageUrl(value)) {
+    return resolveCandidateImage(supabase, value, variant);
+  }
+
+  return unstable_cache(
+    async () => resolveCandidateImage(supabase, value, variant),
+    ["candidate-image-signed-url", value, variant],
+    { revalidate: SIGNED_IMAGE_URL_CACHE_SECONDS },
+  )();
+}
+
 async function attachTransformedImageUrlsToCandidates(
   supabase: NonNullable<Awaited<ReturnType<typeof createClient>>>,
   candidates: Candidate[],
@@ -143,7 +160,7 @@ async function attachTransformedImageUrlsToCandidates(
   const resolvedEntries = await Promise.all(
     candidates.map(async (candidate) => [
       candidate.id,
-      await resolveCandidateImage(supabase, candidate.image_url, variant),
+      await resolveCandidateImageCached(supabase, candidate.image_url, variant),
     ] as const),
   );
 
@@ -412,7 +429,7 @@ async function loadCandidateByIdUncached(id: string) {
   const candidate = mapCandidate(data);
 
   const [image_url, creatorName] = await Promise.all([
-    resolveCandidateImage(supabase, candidate.image_url, "detail"),
+    resolveCandidateImageCached(supabase, candidate.image_url, "detail"),
     getMembershipFullNameByUserId(supabase, data.created_by),
   ]);
 
@@ -797,7 +814,7 @@ async function loadCandidatePhotosUncached(candidateId: string): Promise<Candida
       photo.id,
       isDirectImageUrl(photo.image_url)
         ? photo.image_url
-        : await resolveCandidateImage(supabase, photo.image_url, "editorThumb"),
+        : await resolveCandidateImageCached(supabase, photo.image_url, "editorThumb"),
     ] as const),
   );
   const resolvedById = new Map(resolvedEntries);
@@ -888,8 +905,8 @@ async function loadProfileGalleryImagesUncached(candidateId: string): Promise<Ca
       }
 
       const [mainUrl, thumbUrl] = await Promise.all([
-        resolveCandidateImage(supabase, path, "gallery"),
-        resolveCandidateImage(supabase, path, "galleryThumb"),
+        resolveCandidateImageCached(supabase, path, "gallery"),
+        resolveCandidateImageCached(supabase, path, "galleryThumb"),
       ]);
 
       if (!mainUrl || !thumbUrl) {


### PR DESCRIPTION
## 요약

- 데스크톱 대시보드의 고정 높이/내부 스크롤 구조를 제거해 페이지 전체가 자연스럽게 스크롤되도록 개선
- 대시보드 통계/필터 영역과 인벤토리 우측 타임라인을 데스크톱에서 sticky 처리
- Supabase Storage 변환 signed URL을 이미지 path + variant 단위로 22시간 캐시
- 대시보드 후보 캐시를 15분에서 22시간으로 확장
- 대시보드 후보 카드의 상세 페이지 자동 prefetch를 비활성화해 불필요한 데이터 호출 감소

## 배경

운영자가 대시보드를 일상 업무 도구로 사용할 때, 기존 데스크톱 레이아웃은 페이지 전체가 아닌 각 칸반 레인/패널만 독립적으로 스크롤되어 마우스 휠 동작이 어색했습니다.

또한 대시보드/상세 진입 시 Supabase Storage 변환 signed URL 생성이 반복되어 콜드 패스에서 이동 지연과 사용량 증가가 발생했습니다. 현재 대시보드는 승인된 사용자만 접근 가능하고, 후보/매칭 변경 시 기존 캐시 무효화 경로가 이미 정착되어 있어 캐시 윈도우를 늘려도 stale 위험이 낮다고 판단했습니다.

## 검증

- `npm run typecheck`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized candidate image caching for faster profile loading times.
  * Enhanced dashboard navigation efficiency.

* **Dashboard & UI Updates**
  * Refined layout spacing and container positioning across dashboard views.
  * Improved sticky header behavior and scrolling on larger screens.
  * Enhanced overall usability of dashboard layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->