### PR TITLE
Support 1:N match pairs and unmatch

### DIFF
--- a/app/(member)/dashboard/_components/dashboard-content.tsx
+++ b/app/(member)/dashboard/_components/dashboard-content.tsx
@@ -4,6 +4,7 @@ import { DashboardFlowBoard, type DashboardBoardCandidate } from "./dashboard-fl
 import { DashboardInventoryView } from "./dashboard-inventory-view";
 import { canEditCandidates } from "@/lib/role-utils";
 import { DashboardViewMode } from "@/lib/types";
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { AppRole, Candidate, TimelineEvent } from "@/lib/types";
 
 type DashboardContentProps = {
@@ -12,6 +13,7 @@ type DashboardContentProps = {
   boardCandidates: DashboardBoardCandidate[];
   visibleBoardCandidates: DashboardBoardCandidate[];
   timelineEvents: TimelineEvent[];
+  activeMatchPairs: ActiveMatchPair[];
   role: AppRole;
 };
 
@@ -21,6 +23,7 @@ export function DashboardContent({
   boardCandidates,
   visibleBoardCandidates,
   timelineEvents,
+  activeMatchPairs,
   role,
 }: DashboardContentProps) {
   return (
@@ -30,6 +33,7 @@ export function DashboardContent({
           <DashboardFlowBoard
             candidates={visibleBoardCandidates}
             allCandidates={boardCandidates}
+            activeMatchPairs={activeMatchPairs}
             role={role}
           />
         </section>

--- a/app/(member)/dashboard/_components/dashboard-flow-board.tsx
+++ b/app/(member)/dashboard/_components/dashboard-flow-board.tsx
@@ -4,9 +4,11 @@ import { useEffect, useId, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import type { DragEndEvent, DragOverEvent, DragStartEvent } from "@dnd-kit/core";
-import { moveCandidatePairStatus, moveCandidateStatus } from "@/lib/admin-actions";
+import { moveCandidatePairStatus, moveCandidateStatus, unmatchPair } from "@/lib/admin-actions";
 import { formatCandidateBrief } from "@/lib/candidate-display";
 import { canEditCandidates, canManageRoles } from "@/lib/role-utils";
+import { parsePairDraggableId } from "./flow-board-pair-card";
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { AppRole, Candidate, CandidateStatus } from "@/lib/types";
 import { PairMatchDialog } from "./pair-match-dialog";
 import { FlowBoardCardBody } from "./flow-board-card";
@@ -45,6 +47,7 @@ type PairComposerState = {
 type DashboardFlowBoardProps = {
   candidates: DashboardBoardCandidate[];
   allCandidates: DashboardBoardCandidate[];
+  activeMatchPairs: ActiveMatchPair[];
   role: AppRole;
 };
 
@@ -85,8 +88,8 @@ function getEligiblePairOptions(
     if (candidate.id === source.id) return false;
     if (candidate.gender === source.gender) return false;
     if (candidate.status === "graduated" || candidate.status === "archived") return false;
-    if (candidate.paired_candidate_id && candidate.paired_candidate_id !== source.id) return false;
 
+    // 1:N 매칭 허용 — 이미 다른 상대와 진행 중인 후보도 새 상대로 선택할 수 있다.
     if (targetStatus === "couple" && source.paired_candidate_id) {
       return candidate.id === source.paired_candidate_id;
     }
@@ -97,7 +100,12 @@ function getEligiblePairOptions(
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export function DashboardFlowBoard({ candidates, allCandidates, role }: DashboardFlowBoardProps) {
+export function DashboardFlowBoard({
+  candidates,
+  allCandidates,
+  activeMatchPairs,
+  role,
+}: DashboardFlowBoardProps) {
   const router = useRouter();
   const [items, setItems] = useState(candidates);
   const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -218,6 +226,58 @@ export function DashboardFlowBoard({ candidates, allCandidates, role }: Dashboar
     });
   };
 
+  // 관계 단위 매칭 종료 (1:N — 한 페어 카드만 적극검토로 되돌릴 때).
+  // 남은 매칭 여부에 따른 status 재계산은 서버가 처리하므로 새로고침으로 반영한다.
+  const executeUnmatch = (candidateAId: string, candidateBId: string) => {
+    const affectedIds = new Set([candidateAId, candidateBId]);
+    setNotice(null);
+    setPendingCandidateIds(affectedIds);
+
+    startTransition(async () => {
+      const result = await unmatchPair(candidateAId, candidateBId);
+      setPendingCandidateIds(new Set());
+
+      if (!result.ok) {
+        setNotice(result.message ?? "매칭 종료에 실패했습니다.");
+        return;
+      }
+
+      router.refresh();
+    });
+  };
+
+  const handleSingleCardDrag = (
+    candidate: DashboardBoardCandidate,
+    targetStatus: CandidateStatus,
+  ) => {
+    if (candidate.status === "couple" && !canReopenCouple) return;
+    if (candidate.status === targetStatus) return;
+
+    if (targetStatus === "matched" || targetStatus === "couple") {
+      const options = getEligiblePairOptions(candidate, allCandidates, targetStatus);
+      const existingCounterpartId =
+        candidate.paired_candidate_id &&
+        options.some((option) => option.id === candidate.paired_candidate_id)
+          ? candidate.paired_candidate_id
+          : null;
+
+      // 커플완성으로 이동 시 이미 페어가 있으면 다이얼로그 없이 바로 이동
+      if (targetStatus === "couple" && existingCounterpartId) {
+        executePairMove(candidate.id, existingCounterpartId, targetStatus);
+        return;
+      }
+
+      setPairComposer({
+        candidateId: candidate.id,
+        targetStatus,
+        counterpartId: existingCounterpartId ?? "",
+      });
+      return;
+    }
+
+    moveSingleItem(candidate.id, targetStatus);
+  };
+
   const confirmPairMove = () => {
     if (!pairComposer?.counterpartId) {
       setNotice("상대 후보를 선택해야 합니다.");
@@ -252,35 +312,38 @@ export function DashboardFlowBoard({ candidates, allCandidates, role }: Dashboar
     const { active, over } = event;
     if (!over || !canOperate) return;
 
-    const candidateId = active.id as string;
     const targetStatus = over.id as CandidateStatus;
-
     if (!PRIMARY_LANES.some((lane) => lane.key === targetStatus)) return;
 
-    const candidate = candidateDirectory.get(candidateId);
-    if (!candidate) return;
-    if (candidate.status === "couple" && !canReopenCouple) return;
-    if (candidate.status === targetStatus) return;
+    // 페어 카드(매칭진행중/커플완성)는 관계(양쪽 id)를 인코딩한 draggable id를 갖는다.
+    const pairInfo = parsePairDraggableId(active.id as string);
 
-    if (targetStatus === "matched" || targetStatus === "couple") {
-      const options = getEligiblePairOptions(candidate, allCandidates, targetStatus);
-      const existingCounterpartId =
-        candidate.paired_candidate_id &&
-        options.some((option) => option.id === candidate.paired_candidate_id)
-          ? candidate.paired_candidate_id
-          : null;
+    if (pairInfo) {
+      const primary = candidateDirectory.get(pairInfo.primaryId);
+      if (!primary) return;
+      if (primary.status === "couple" && !canReopenCouple) return;
+      if (primary.status === targetStatus) return;
 
-      // 커플완성으로 이동 시 이미 페어가 있으면 다이얼로그 없이 바로 이동
-      if (targetStatus === "couple" && existingCounterpartId) {
-        executePairMove(candidateId, existingCounterpartId, targetStatus);
-        return;
+      // 짝이 있는 관계 → 관계 단위로 처리 (1:N에서 해당 관계만 종료/커플 확정)
+      if (pairInfo.partnerId) {
+        if (targetStatus === "active") {
+          executeUnmatch(pairInfo.primaryId, pairInfo.partnerId);
+          return;
+        }
+        if (targetStatus === "couple") {
+          executePairMove(pairInfo.primaryId, pairInfo.partnerId, "couple");
+          return;
+        }
       }
 
-      setPairComposer({ candidateId, targetStatus, counterpartId: existingCounterpartId ?? "" });
+      // 짝 없는 잔여 반쪽·기타(커플 재오픈 등)는 단일 후보 흐름으로 위임
+      handleSingleCardDrag(primary, targetStatus);
       return;
     }
 
-    moveSingleItem(candidateId, targetStatus);
+    const candidate = candidateDirectory.get(active.id as string);
+    if (!candidate) return;
+    handleSingleCardDrag(candidate, targetStatus);
   };
 
   const handleDragCancel = () => {
@@ -290,9 +353,13 @@ export function DashboardFlowBoard({ candidates, allCandidates, role }: Dashboar
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
-  const draggingCandidate = draggingId ? candidateDirectory.get(draggingId) : null;
-  const draggingPartner = draggingCandidate?.paired_candidate_id
-    ? (candidateDirectory.get(draggingCandidate.paired_candidate_id) ?? null)
+  const draggingPairInfo = draggingId ? parsePairDraggableId(draggingId) : null;
+  const draggingPrimaryId = draggingPairInfo ? draggingPairInfo.primaryId : draggingId;
+  const draggingCandidate = draggingPrimaryId
+    ? (candidateDirectory.get(draggingPrimaryId) ?? null)
+    : null;
+  const draggingPartner = draggingPairInfo?.partnerId
+    ? (candidateDirectory.get(draggingPairInfo.partnerId) ?? null)
     : null;
 
   const sharedLaneProps = {
@@ -300,6 +367,7 @@ export function DashboardFlowBoard({ candidates, allCandidates, role }: Dashboar
     canOperate,
     pendingCandidateIds,
     candidateDirectory,
+    activeMatchPairs,
   };
 
   return (

--- a/app/(member)/dashboard/_components/dashboard-main.tsx
+++ b/app/(member)/dashboard/_components/dashboard-main.tsx
@@ -1,5 +1,6 @@
 import { ManagerDashboard } from "./manager-dashboard";
 import { buildTimelineEvents, getDashboardCandidates, getDashboardTimelineData } from "@/lib/data";
+import { buildActiveMatchPairs } from "@/lib/match-flow-columns";
 import { DashboardViewMode } from "@/lib/types";
 import type { Membership } from "@/lib/types";
 
@@ -18,11 +19,13 @@ export async function DashboardMain({ membership, initialView }: DashboardMainPr
     timelineData.records,
     new Map(candidates.map((candidate) => [candidate.id, candidate])),
   );
+  const activeMatchPairs = buildActiveMatchPairs(timelineData.records);
 
   return (
     <ManagerDashboard
       candidates={candidates}
       timelineEvents={timelineEvents}
+      activeMatchPairs={activeMatchPairs}
       membership={membership}
       initialView={initialView}
     />

--- a/app/(member)/dashboard/_components/dashboard-stat-bar.tsx
+++ b/app/(member)/dashboard/_components/dashboard-stat-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import Link from "next/link";
 import { cn } from "@/lib/cn";
 import type { Candidate, TimelineEvent } from "@/lib/types";
 
@@ -29,22 +30,40 @@ export function DashboardStatBar({ candidates, timelineEvents }: DashboardStatBa
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4">
-      {STATS_CONFIG.map((stat, index) => (
-        <div
-          key={stat.key}
-          className={cn(
-            "flex flex-1 items-center justify-center gap-2 px-3 py-2.5 sm:gap-2.5 sm:px-4 sm:py-3.5",
-            index < 2 && "border-b border-slate-100 sm:border-b-0",
-            index % 2 === 0 && "border-r border-slate-100",
-            index === 1 && "sm:border-r sm:border-slate-100",
-          )}
-        >
-          <span className="text-sm font-medium text-slate-500">{stat.label}</span>
-          <strong className="text-sm font-semibold tabular-nums text-primary">
-            {values[stat.key]}
-          </strong>
-        </div>
-      ))}
+      {STATS_CONFIG.map((stat, index) => {
+        const cellClassName = cn(
+          "flex flex-1 items-center justify-center gap-2 px-3 py-2.5 sm:gap-2.5 sm:px-4 sm:py-3.5",
+          index < 2 && "border-b border-slate-100 sm:border-b-0",
+          index % 2 === 0 && "border-r border-slate-100",
+          index === 1 && "sm:border-r sm:border-slate-100",
+        );
+        const inner = (
+          <>
+            <span className="text-sm font-medium text-slate-500">{stat.label}</span>
+            <strong className="text-sm font-semibold tabular-nums text-primary">
+              {values[stat.key]}
+            </strong>
+          </>
+        );
+
+        if (stat.key === "record") {
+          return (
+            <Link
+              key={stat.key}
+              href="/timeline"
+              className={cn(cellClassName, "cursor-pointer transition-colors hover:bg-rose-50/60")}
+            >
+              {inner}
+            </Link>
+          );
+        }
+
+        return (
+          <div key={stat.key} className={cellClassName}>
+            {inner}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/app/(member)/dashboard/_components/dashboard-workspace.tsx
+++ b/app/(member)/dashboard/_components/dashboard-workspace.tsx
@@ -8,11 +8,13 @@ import { DashboardStatBar } from "./dashboard-stat-bar";
 import { DashboardToolbar } from "./dashboard-toolbar";
 import { DashboardViewToggle } from "./dashboard-view-toggle";
 import { DashboardViewMode } from "@/lib/types";
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { AppRole, Candidate, TimelineEvent } from "@/lib/types";
 
 type DashboardWorkspaceProps = {
   candidates: Candidate[];
   timelineEvents: TimelineEvent[];
+  activeMatchPairs: ActiveMatchPair[];
   role: AppRole;
   initialView?: DashboardViewMode;
 };
@@ -20,6 +22,7 @@ type DashboardWorkspaceProps = {
 export function DashboardWorkspace({
   candidates,
   timelineEvents,
+  activeMatchPairs,
   role,
   initialView = DashboardViewMode.FLOW,
 }: DashboardWorkspaceProps) {
@@ -162,6 +165,7 @@ export function DashboardWorkspace({
           boardCandidates={boardCandidates}
           visibleBoardCandidates={visibleBoardCandidates}
           timelineEvents={timelineEvents}
+          activeMatchPairs={activeMatchPairs}
           role={role}
         />
       </div>

--- a/app/(member)/dashboard/_components/flow-board-desktop-view.tsx
+++ b/app/(member)/dashboard/_components/flow-board-desktop-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { AppRole, CandidateStatus } from "@/lib/types";
 import type { DashboardBoardCandidate } from "./dashboard-flow-board";
 import { PRIMARY_LANES } from "./dashboard-flow-board";
@@ -9,6 +10,7 @@ import { FlowBoardLane, groupCandidatesByStatus } from "./flow-board-lane";
 
 type FlowBoardDesktopViewProps = {
   items: DashboardBoardCandidate[];
+  activeMatchPairs: ActiveMatchPair[];
   dropTarget: CandidateStatus | null;
   role: AppRole;
   canOperate: boolean;
@@ -20,6 +22,7 @@ type FlowBoardDesktopViewProps = {
 
 export function FlowBoardDesktopView({
   items,
+  activeMatchPairs,
   dropTarget,
   role,
   canOperate,
@@ -35,6 +38,7 @@ export function FlowBoardDesktopView({
           title={lane.title}
           description={lane.description}
           items={groupCandidatesByStatus(items, lane.key)}
+          activeMatchPairs={activeMatchPairs}
           isDropTarget={dropTarget === lane.key}
           role={role}
           canOperate={canOperate}

--- a/app/(member)/dashboard/_components/flow-board-lane.tsx
+++ b/app/(member)/dashboard/_components/flow-board-lane.tsx
@@ -4,6 +4,7 @@ import { useDroppable } from "@dnd-kit/core";
 import { cn } from "@/lib/cn";
 import { getLaneSurfaceClass } from "@/lib/status-ui";
 import { Badge } from "@/components/ui/badge";
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { AppRole, CandidateStatus } from "@/lib/types";
 import type { DashboardBoardCandidate } from "./dashboard-flow-board";
 import { FlowBoardActiveLaneContent } from "./flow-board-active-lane";
@@ -17,6 +18,7 @@ export type FlowBoardLaneProps = {
   description: string;
   compact?: boolean;
   items: DashboardBoardCandidate[];
+  activeMatchPairs: ActiveMatchPair[];
   isDropTarget: boolean;
   role: AppRole;
   canOperate: boolean;
@@ -66,6 +68,7 @@ export function FlowBoardLane({
   description,
   compact = false,
   items,
+  activeMatchPairs,
   isDropTarget,
   role,
   canOperate,
@@ -98,6 +101,7 @@ export function FlowBoardLane({
       {isPairedLane ? (
         <FlowBoardPairedLaneContent
           items={items}
+          activeMatchPairs={activeMatchPairs}
           role={role}
           canOperate={canOperate}
           pendingCandidateIds={pendingCandidateIds}

--- a/app/(member)/dashboard/_components/flow-board-mobile-view.tsx
+++ b/app/(member)/dashboard/_components/flow-board-mobile-view.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/cn";
 import { getStatusBadgeClass } from "@/lib/status-ui";
 import { Button } from "@/components/ui/button";
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { AppRole, CandidateStatus } from "@/lib/types";
 import type { DashboardBoardCandidate } from "./dashboard-flow-board";
 import { PRIMARY_LANES } from "./dashboard-flow-board";
@@ -12,6 +13,7 @@ import { FlowBoardLane, groupCandidatesByStatus } from "./flow-board-lane";
 
 type FlowBoardMobileViewProps = {
   items: DashboardBoardCandidate[];
+  activeMatchPairs: ActiveMatchPair[];
   mobileLane: CandidateStatus;
   onMobileLaneChange: (lane: CandidateStatus) => void;
   dropTarget: CandidateStatus | null;
@@ -25,6 +27,7 @@ type FlowBoardMobileViewProps = {
 
 export function FlowBoardMobileView({
   items,
+  activeMatchPairs,
   mobileLane,
   onMobileLaneChange,
   dropTarget,
@@ -73,6 +76,7 @@ export function FlowBoardMobileView({
         description={PRIMARY_LANES.find((lane) => lane.key === mobileLane)?.description ?? ""}
         compact
         items={groupCandidatesByStatus(items, mobileLane)}
+        activeMatchPairs={activeMatchPairs}
         isDropTarget={dropTarget === mobileLane}
         role={role}
         canOperate={canOperate}

--- a/app/(member)/dashboard/_components/flow-board-pair-card.tsx
+++ b/app/(member)/dashboard/_components/flow-board-pair-card.tsx
@@ -11,6 +11,25 @@ import type { AppRole } from "@/lib/types";
 import type { DashboardBoardCandidate } from "./dashboard-flow-board";
 import type { PairedLaneRow } from "./flow-board-paired-lane";
 
+// 페어 카드의 draggable id는 관계(양쪽 후보 id)를 인코딩한다.
+// 1:N에서 한 후보가 여러 페어 카드에 등장해도 id가 충돌하지 않도록 하기 위함.
+export function buildPairDraggableId(row: PairedLaneRow): string {
+  return `pair::${row.male?.id ?? "none"}::${row.female?.id ?? "none"}`;
+}
+
+export function parsePairDraggableId(
+  id: string,
+): { primaryId: string; partnerId: string | null } | null {
+  if (!id.startsWith("pair::")) return null;
+  const [, maleRaw, femaleRaw] = id.split("::");
+  const maleId = maleRaw && maleRaw !== "none" ? maleRaw : null;
+  const femaleId = femaleRaw && femaleRaw !== "none" ? femaleRaw : null;
+  const primaryId = maleId ?? femaleId;
+  if (!primaryId) return null;
+  const partnerId = maleId && femaleId ? (primaryId === maleId ? femaleId : maleId) : null;
+  return { primaryId, partnerId };
+}
+
 type DraggableWrapperProps = {
   id: string;
   disabled: boolean;
@@ -217,7 +236,7 @@ export function FlowBoardPairCard({
 
   return (
     <DraggableWrapper
-      id={primaryCandidate?.id ?? "pair-placeholder"}
+      id={buildPairDraggableId(row)}
       disabled={draggableDisabled}
       className={cn(isPending && "pointer-events-none opacity-60")}
     >

--- a/app/(member)/dashboard/_components/flow-board-paired-lane.tsx
+++ b/app/(member)/dashboard/_components/flow-board-paired-lane.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { AppRole } from "@/lib/types";
 import type { DashboardBoardCandidate } from "./dashboard-flow-board";
 import { FlowBoardPairCard } from "./flow-board-pair-card";
@@ -13,6 +14,7 @@ export type PairedLaneRow = {
 
 type FlowBoardPairedLaneContentProps = {
   items: DashboardBoardCandidate[];
+  activeMatchPairs: ActiveMatchPair[];
   role: AppRole;
   canOperate: boolean;
   pendingCandidateIds: ReadonlySet<string>;
@@ -30,32 +32,48 @@ function newestCreatedAtInPair(row: PairedLaneRow): string {
   return times.reduce((best, t) => (t > best ? t : best), times[0]);
 }
 
-function buildPairedLaneRows(laneItems: DashboardBoardCandidate[]): PairedLaneRow[] {
-  const byId = new Map(laneItems.map((c) => [c.id, c]));
-  const visited = new Set<string>();
+function toLaneRow(
+  first: DashboardBoardCandidate,
+  second: DashboardBoardCandidate,
+): PairedLaneRow {
+  const members = [first, second];
+  const male = members.find((member) => member.gender === "남") ?? null;
+  const female = members.find((member) => member.gender === "여") ?? null;
+  return male || female ? { male, female } : { male: first, female: second };
+}
+
+// 현재 매칭 관계(activeMatchPairs) 기준으로 페어 행을 만든다.
+// 1:N에서는 한 후보가 여러 관계에 속할 수 있어 같은 후보가 여러 행에 등장한다.
+function buildPairedLaneRows(
+  laneItems: DashboardBoardCandidate[],
+  activeMatchPairs: ActiveMatchPair[],
+): PairedLaneRow[] {
+  const byId = new Map(laneItems.map((candidate) => [candidate.id, candidate]));
   const rows: PairedLaneRow[] = [];
+  const seenPairKeys = new Set<string>();
+  const pairedCandidateIds = new Set<string>();
 
-  for (const c of laneItems) {
-    if (visited.has(c.id)) continue;
+  for (const pair of activeMatchPairs) {
+    const first = byId.get(pair.aId);
+    const second = byId.get(pair.bId);
+    if (!first || !second) continue;
 
-    const partner = c.paired_candidate_id ? byId.get(c.paired_candidate_id) : undefined;
+    const key = [pair.aId, pair.bId].sort().join(":");
+    if (seenPairKeys.has(key)) continue;
+    seenPairKeys.add(key);
 
-    if (partner) {
-      visited.add(c.id);
-      visited.add(partner.id);
-      const members = [c, partner];
-      const male = members.find((m) => m.gender === "남") ?? null;
-      const female = members.find((m) => m.gender === "여") ?? null;
-      rows.push(male || female ? { male, female } : { male: c, female: partner });
+    pairedCandidateIds.add(first.id);
+    pairedCandidateIds.add(second.id);
+    rows.push(toLaneRow(first, second));
+  }
+
+  // 관계 쌍이 잡히지 않은 잔여 후보(레코드 누락 등)는 한쪽만 채운 행으로 표시
+  for (const candidate of laneItems) {
+    if (pairedCandidateIds.has(candidate.id)) continue;
+    if (candidate.gender === "여") {
+      rows.push({ male: null, female: candidate });
     } else {
-      visited.add(c.id);
-      if (c.gender === "남") {
-        rows.push({ male: c, female: null });
-      } else if (c.gender === "여") {
-        rows.push({ male: null, female: c });
-      } else {
-        rows.push({ male: c, female: null });
-      }
+      rows.push({ male: candidate, female: null });
     }
   }
 
@@ -67,11 +85,12 @@ function buildPairedLaneRows(laneItems: DashboardBoardCandidate[]): PairedLaneRo
 
 export function FlowBoardPairedLaneContent({
   items,
+  activeMatchPairs,
   role,
   canOperate,
   pendingCandidateIds,
 }: FlowBoardPairedLaneContentProps) {
-  const pairedRows = buildPairedLaneRows(items);
+  const pairedRows = buildPairedLaneRows(items, activeMatchPairs);
 
   return (
     <div className="mt-4 flex flex-col gap-3">

--- a/app/(member)/dashboard/_components/manager-dashboard.tsx
+++ b/app/(member)/dashboard/_components/manager-dashboard.tsx
@@ -3,11 +3,13 @@
 import { DashboardWorkspace } from "./dashboard-workspace";
 import { SakuraRain } from "@/components/sakura-rain";
 import { DashboardViewMode } from "@/lib/types";
+import type { ActiveMatchPair } from "@/lib/match-flow-columns";
 import type { Candidate, Membership, TimelineEvent } from "@/lib/types";
 
 type ManagerDashboardProps = {
   candidates: Candidate[];
   timelineEvents: TimelineEvent[];
+  activeMatchPairs: ActiveMatchPair[];
   membership: Membership;
   initialView?: DashboardViewMode;
 };
@@ -15,6 +17,7 @@ type ManagerDashboardProps = {
 export function ManagerDashboard({
   candidates,
   timelineEvents,
+  activeMatchPairs,
   membership,
   initialView = DashboardViewMode.FLOW,
 }: ManagerDashboardProps) {
@@ -27,6 +30,7 @@ export function ManagerDashboard({
         <DashboardWorkspace
           candidates={candidates}
           timelineEvents={timelineEvents}
+          activeMatchPairs={activeMatchPairs}
           role={membership.role}
           initialView={initialView}
         />

--- a/components/operator-desk-controls.tsx
+++ b/components/operator-desk-controls.tsx
@@ -14,10 +14,15 @@ const CLOSURE_SELECT_VALUE = "__match_closure__";
 // 매칭진행중·커플완성 전환은 대시보드 칸반 전용 — 상세에서는 노출 중(active)과 종료만 다룸
 const STATUS_OPTIONS: CandidateStatus[] = ["active"];
 
+type OperatorDeskPartner = {
+  id: string;
+  label: string;
+};
+
 type OperatorDeskControlsProps = {
   candidateId: string;
   currentStatus: CandidateStatus;
-  pairedCandidateId: string | null;
+  currentPartners: OperatorDeskPartner[];
   canOperate: boolean;
   isSuperAdmin?: boolean;
 };
@@ -25,13 +30,16 @@ type OperatorDeskControlsProps = {
 export function OperatorDeskControls({
   candidateId,
   currentStatus,
-  pairedCandidateId,
+  currentPartners,
   canOperate,
   isSuperAdmin = false,
 }: OperatorDeskControlsProps) {
-  const hasPair = Boolean(pairedCandidateId);
+  const hasPair = currentPartners.length > 0;
+  // currentPartners는 매 렌더 새 배열이라 첫 상대 id를 키로 사용해 동기화한다.
+  const firstPartnerId = currentPartners[0]?.id ?? "";
   const [selectValue, setSelectValue] = useState<string>(currentStatus);
   const [closureMode, setClosureMode] = useState(false);
+  const [closureCounterpartId, setClosureCounterpartId] = useState<string>(firstPartnerId);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const closureFormRef = useRef<HTMLFormElement>(null);
@@ -40,8 +48,9 @@ export function OperatorDeskControls({
   useEffect(() => {
     setSelectValue(currentStatus);
     setClosureMode(false);
+    setClosureCounterpartId(firstPartnerId);
     setInlineError(null);
-  }, [currentStatus]);
+  }, [currentStatus, firstPartnerId]);
 
   const handleCloseMatch = () => {
     if (isPending || !closureFormRef.current) return;
@@ -49,9 +58,14 @@ export function OperatorDeskControls({
       closureFormRef.current.elements.namedItem("closureReason") as HTMLTextAreaElement
     )?.value?.trim();
     if (!closureReason) return;
+    const counterpartId =
+      closureCounterpartId && currentPartners.some((partner) => partner.id === closureCounterpartId)
+        ? closureCounterpartId
+        : (currentPartners[0]?.id ?? "");
     const formData = new FormData();
     formData.set("candidateId", candidateId);
     formData.set("closureReason", closureReason);
+    if (counterpartId) formData.set("counterpartId", counterpartId);
     startTransition(async () => {
       await closeMatchWithRecord(formData);
     });
@@ -144,6 +158,23 @@ export function OperatorDeskControls({
               </p>
             ) : (
               <form ref={closureFormRef} onSubmit={(e) => e.preventDefault()} className="grid gap-3">
+                {currentPartners.length > 1 ? (
+                  <label className="grid gap-1.5">
+                    <span className="text-xs font-semibold text-rose-600/90">종료할 상대</span>
+                    <select
+                      value={closureCounterpartId}
+                      disabled={isPending}
+                      onChange={(event) => setClosureCounterpartId(event.target.value)}
+                      className="h-11 rounded-xl border border-rose-100/80 bg-white/95 px-3 text-sm text-slate-700 shadow-sm outline-none focus:border-rose-200 focus:ring-2 focus:ring-rose-100"
+                    >
+                      {currentPartners.map((partner) => (
+                        <option key={partner.id} value={partner.id}>
+                          {partner.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
                 <label className="grid gap-1.5">
                   <span className="text-xs font-semibold text-rose-600/90">
                     종료 사유 (예: 성향 차이, 연락 두절 등)

--- a/components/profile-detail-content.tsx
+++ b/components/profile-detail-content.tsx
@@ -81,9 +81,20 @@ export async function ProfileDetailContent({ id, message, membership }: ProfileD
     ),
   ];
 
+  // 현재 매칭 상대는 진행중/커플(closed가 아닌) 매칭 레코드에서 도출 (1:N).
+  const currentPartnerIds = [
+    ...new Set(
+      records
+        .filter((record) => record.outcome !== "closed" && record.counterpart_candidate_id)
+        .map((record) => record.counterpart_candidate_id as string),
+    ),
+  ];
+
   const relatedCandidateIds = [
     ...new Set(
-      [candidate.paired_candidate_id, ...pastCounterpartIds].filter((x): x is string => Boolean(x)),
+      [candidate.paired_candidate_id, ...currentPartnerIds, ...pastCounterpartIds].filter(
+        (x): x is string => Boolean(x),
+      ),
     ),
   ];
 
@@ -92,9 +103,15 @@ export async function ProfileDetailContent({ id, message, membership }: ProfileD
     : [];
 
   const relatedById = new Map(relatedCandidates.map((c) => [c.id, c]));
-  const counterpartCandidate = candidate.paired_candidate_id
-    ? (relatedById.get(candidate.paired_candidate_id) ?? null)
-    : null;
+
+  const currentPartners = currentPartnerIds
+    .map((partnerId) => relatedById.get(partnerId))
+    .filter((partner): partner is (typeof relatedCandidates)[number] => Boolean(partner));
+
+  const currentPartnerOptions = currentPartners.map((partner) => ({
+    id: partner.id,
+    label: getCandidateGalleryLabel(partner),
+  }));
 
   const counterpartsById = Object.fromEntries(
     pastCounterpartIds
@@ -112,10 +129,6 @@ export async function ProfileDetailContent({ id, message, membership }: ProfileD
     membership.user_id,
     candidate.created_by,
   );
-  const counterpartHeroUrl =
-    counterpartCandidate && isRenderableImageUrl(counterpartCandidate.image_url)
-      ? counterpartCandidate.image_url
-      : null;
   const metaChips = getStudioMetaChips(candidate);
   const deskMessage = getDeskMessage(message);
 
@@ -254,40 +267,52 @@ export async function ProfileDetailContent({ id, message, membership }: ProfileD
                   <OperatorDeskControls
                     candidateId={candidate.id}
                     currentStatus={candidate.status}
-                    pairedCandidateId={candidate.paired_candidate_id}
+                    currentPartners={currentPartnerOptions}
                     canOperate={canOperate}
                     isSuperAdmin={isSuperAdmin}
                   />
                 </div>
 
-                {counterpartCandidate ? (
+                {currentPartners.length ? (
                   <div className="mt-6 rounded-2xl border border-orange-100/70 bg-orange-50/50 p-4 backdrop-blur-sm">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-orange-500/90">
-                      Current Pair · 연결 중
+                      Current Pair · 연결 중{currentPartners.length > 1 ? ` (${currentPartners.length})` : ""}
                     </p>
-                    <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:items-start">
-                      <div className="w-full max-w-[200px] shrink-0 border border-white/80 bg-rose-50 shadow-[0_12px_36px_rgba(251,146,60,0.2)] sm:max-w-[176px]">
-                        <ProfilePortrait
-                          imageUrl={counterpartHeroUrl}
-                          sizes="200px"
-                          roundedClassName="rounded-2xl"
-                          className="border-0"
-                        />
-                      </div>
-                      <div className="min-w-0 flex-1 text-center sm:text-left">
-                        <p className="text-base font-semibold text-slate-800">
-                          {getCandidateGalleryLabel(counterpartCandidate)}
-                        </p>
-                        <p className="mt-1 text-sm font-medium text-slate-600">
-                          {getTitle(counterpartCandidate)}
-                        </p>
-                        <Link
-                          href={`/profiles/${counterpartCandidate.id}`}
-                          className="mt-4 inline-flex text-sm font-semibold text-rose-600 underline-offset-2 hover:text-rose-700 hover:underline"
-                        >
-                          상대 상세 보기
-                        </Link>
-                      </div>
+                    <div className="mt-4 flex flex-col gap-5">
+                      {currentPartners.map((partner) => {
+                        const partnerHeroUrl = isRenderableImageUrl(partner.image_url)
+                          ? partner.image_url
+                          : null;
+                        return (
+                          <div
+                            key={partner.id}
+                            className="flex flex-col items-center gap-4 sm:flex-row sm:items-start"
+                          >
+                            <div className="w-full max-w-[200px] shrink-0 border border-white/80 bg-rose-50 shadow-[0_12px_36px_rgba(251,146,60,0.2)] sm:max-w-[176px]">
+                              <ProfilePortrait
+                                imageUrl={partnerHeroUrl}
+                                sizes="200px"
+                                roundedClassName="rounded-2xl"
+                                className="border-0"
+                              />
+                            </div>
+                            <div className="min-w-0 flex-1 text-center sm:text-left">
+                              <p className="text-base font-semibold text-slate-800">
+                                {getCandidateGalleryLabel(partner)}
+                              </p>
+                              <p className="mt-1 text-sm font-medium text-slate-600">
+                                {getTitle(partner)}
+                              </p>
+                              <Link
+                                href={`/profiles/${partner.id}`}
+                                className="mt-4 inline-flex text-sm font-semibold text-rose-600 underline-offset-2 hover:text-rose-700 hover:underline"
+                              >
+                                상대 상세 보기
+                              </Link>
+                            </div>
+                          </div>
+                        );
+                      })}
                     </div>
                   </div>
                 ) : null}

--- a/lib/admin-actions.ts
+++ b/lib/admin-actions.ts
@@ -600,6 +600,127 @@ export async function updateCandidateStatus(formData: FormData) {
   redirect(`/profiles/${candidateId}?message=status-updated`);
 }
 
+// ── 1:N 매칭 헬퍼 ──────────────────────────────────────────────────────────
+// 현재 매칭 상대는 단일 paired_candidate_id가 아니라 closed가 아닌 매칭 레코드에서 도출한다.
+
+const UNMATCH_TO_ACTIVE_SUMMARY = "적극검토 단계로 되돌리며 매칭을 종료했습니다.";
+const COUPLE_AUTOCLOSE_SUMMARY = "커플완성 확정으로 다른 진행중 매칭을 종료했습니다.";
+
+type OpenMatchPartner = {
+  partnerId: string;
+  outcome: string;
+  happenedOn: string;
+};
+
+/** 후보가 한쪽으로 들어간 closed가 아닌 매칭의 상대 목록 (최신순, 상대별 1건) */
+async function getOpenMatchPartners(
+  supabase: SupabaseServerClient,
+  candidateId: string,
+): Promise<OpenMatchPartner[]> {
+  const { data } = await supabase
+    .from("cupid_match_records")
+    .select("candidate_id, counterpart_candidate_id, outcome, happened_on")
+    .or(`candidate_id.eq.${candidateId},counterpart_candidate_id.eq.${candidateId}`)
+    .neq("outcome", "closed")
+    .order("happened_on", { ascending: false });
+
+  if (!data) return [];
+
+  const seen = new Set<string>();
+  const partners: OpenMatchPartner[] = [];
+  for (const row of data) {
+    const partnerId =
+      row.candidate_id === candidateId ? row.counterpart_candidate_id : row.candidate_id;
+    if (!partnerId || seen.has(partnerId)) continue;
+    seen.add(partnerId);
+    partners.push({ partnerId, outcome: row.outcome, happenedOn: row.happened_on });
+  }
+  return partners;
+}
+
+/** 진행중/커플 매칭 유무로 후보 status·paired_candidate_id를 재계산 (graduated/archived는 보존) */
+async function recomputeCandidateStatus(
+  supabase: SupabaseServerClient,
+  candidateId: string,
+): Promise<void> {
+  const { data: candidate } = await supabase
+    .from("cupid_candidates")
+    .select("status")
+    .eq("id", candidateId)
+    .maybeSingle();
+
+  if (!candidate || candidate.status === "graduated" || candidate.status === "archived") {
+    return;
+  }
+
+  const partners = await getOpenMatchPartners(supabase, candidateId);
+  const couplePartner = partners.find((partner) => partner.outcome === "couple");
+  if (couplePartner) {
+    await supabase
+      .from("cupid_candidates")
+      .update({ status: "couple", paired_candidate_id: couplePartner.partnerId })
+      .eq("id", candidateId);
+    return;
+  }
+
+  const ongoingPartner = partners.find((partner) =>
+    (ONGOING_MATCH_OUTCOMES as string[]).includes(partner.outcome),
+  );
+  if (ongoingPartner) {
+    await supabase
+      .from("cupid_candidates")
+      .update({ status: "matched", paired_candidate_id: ongoingPartner.partnerId })
+      .eq("id", candidateId);
+    return;
+  }
+
+  await supabase
+    .from("cupid_candidates")
+    .update({ status: "active", paired_candidate_id: null })
+    .eq("id", candidateId);
+}
+
+/** 후보의 모든 비-closed 매칭을 종료 처리하고, 영향받은 상대 id 목록을 반환 */
+async function closeAllMatchesForCandidate(
+  supabase: SupabaseServerClient,
+  candidateId: string,
+  summary: string,
+): Promise<string[]> {
+  const partners = await getOpenMatchPartners(supabase, candidateId);
+  if (!partners.length) return [];
+
+  await supabase
+    .from("cupid_match_records")
+    .update({ outcome: "closed", summary, happened_on: new Date().toISOString().slice(0, 10) })
+    .or(`candidate_id.eq.${candidateId},counterpart_candidate_id.eq.${candidateId}`)
+    .neq("outcome", "closed");
+
+  return partners.map((partner) => partner.partnerId);
+}
+
+/** 후보의 '지정 상대 제외' 다른 비-closed 매칭을 종료하고, 영향받은 상대 id 목록을 반환 */
+async function closeOtherMatchesForCandidate(
+  supabase: SupabaseServerClient,
+  candidateId: string,
+  keepPartnerId: string,
+  summary: string,
+): Promise<string[]> {
+  const others = (await getOpenMatchPartners(supabase, candidateId))
+    .map((partner) => partner.partnerId)
+    .filter((partnerId) => partnerId !== keepPartnerId);
+  if (!others.length) return [];
+
+  const happenedOn = new Date().toISOString().slice(0, 10);
+  for (const otherId of others) {
+    await supabase
+      .from("cupid_match_records")
+      .update({ outcome: "closed", summary, happened_on: happenedOn })
+      .or(buildPairMatchRecordsOrFilter(candidateId, otherId))
+      .neq("outcome", "closed");
+  }
+  return others;
+}
+
 export async function moveCandidateStatus(
   candidateId: string,
   status: "active" | "matched" | "couple" | "graduated" | "archived",
@@ -642,14 +763,40 @@ export async function moveCandidateStatus(
     };
   }
 
+  // 적극검토 복귀: 후보의 모든 진행중/커플 매칭을 종료 이력(closed)으로 남기고
+  // 상대들의 status도 남은 매칭 기준으로 재계산한다 (1:N 안전망).
+  if (normalizedStatus === "active") {
+    const partnerIds = await closeAllMatchesForCandidate(
+      supabase,
+      candidateId,
+      UNMATCH_TO_ACTIVE_SUMMARY,
+    );
+
+    const { error: updateError } = await supabase
+      .from("cupid_candidates")
+      .update({ status: "active", paired_candidate_id: null })
+      .eq("id", candidateId);
+
+    if (updateError) {
+      return { ok: false, message: updateError.message };
+    }
+
+    for (const partnerId of partnerIds) {
+      await recomputeCandidateStatus(supabase, partnerId);
+    }
+
+    revalidateDashboardCaches([candidateId, ...partnerIds]);
+    return { ok: true, status: "active" };
+  }
+
+  // graduated / archived: 기존 동작 유지
   const pairIds = candidate.paired_candidate_id
     ? [candidateId, candidate.paired_candidate_id]
     : [candidateId];
-  const payload =
-    normalizedStatus === "active"
-      ? { status: normalizedStatus, paired_candidate_id: null }
-      : { status: normalizedStatus };
-  const { error } = await supabase.from("cupid_candidates").update(payload).in("id", pairIds);
+  const { error } = await supabase
+    .from("cupid_candidates")
+    .update({ status: normalizedStatus })
+    .in("id", pairIds);
 
   if (error) {
     return { ok: false, message: error.message };
@@ -706,18 +853,25 @@ export async function moveCandidatePairStatus(
     return { ok: false, message: "보조 레인 후보는 다시 적극매물로 되돌린 뒤 매칭해주세요." };
   }
 
-  if (source.paired_candidate_id && source.paired_candidate_id !== counterpart.id) {
-    return {
-      ok: false,
-      message: `${formatCandidateBrief(source)}은(는) 이미 다른 후보와 연결되어 있습니다.`,
-    };
-  }
-
-  if (counterpart.paired_candidate_id && counterpart.paired_candidate_id !== source.id) {
-    return {
-      ok: false,
-      message: `${formatCandidateBrief(counterpart)}은(는) 이미 다른 후보와 연결되어 있습니다.`,
-    };
+  // 1:N 매칭 허용 — 이미 다른 상대와 진행 중이어도 새 상대와 매칭할 수 있다.
+  // 단, 커플완성은 1:1이므로 양측의 '다른' 진행중 매칭을 자동 종료한다.
+  let freedPartnerIds: string[] = [];
+  if (targetStatus === "couple") {
+    const freedFromSource = await closeOtherMatchesForCandidate(
+      supabase,
+      source.id,
+      counterpart.id,
+      COUPLE_AUTOCLOSE_SUMMARY,
+    );
+    const freedFromCounterpart = await closeOtherMatchesForCandidate(
+      supabase,
+      counterpart.id,
+      source.id,
+      COUPLE_AUTOCLOSE_SUMMARY,
+    );
+    freedPartnerIds = [...new Set([...freedFromSource, ...freedFromCounterpart])].filter(
+      (id) => id !== source.id && id !== counterpart.id,
+    );
   }
 
   const { error: sourceUpdateError } = await supabase
@@ -799,12 +953,62 @@ export async function moveCandidatePairStatus(
     }
   }
 
-  revalidateDashboardCaches([source.id, counterpart.id]);
+  // 커플 확정으로 풀린 상대들의 status를 남은 매칭 기준으로 재계산
+  for (const freedPartnerId of freedPartnerIds) {
+    await recomputeCandidateStatus(supabase, freedPartnerId);
+  }
+
+  revalidateDashboardCaches([source.id, counterpart.id, ...freedPartnerIds]);
   return {
     ok: true,
     status: targetStatus as CandidateStatus,
     pair: [source.id, counterpart.id] as const,
   };
+}
+
+/**
+ * 두 후보 사이의 매칭(관계)만 종료한다. 1:N에서 한 페어 카드를 적극검토로 되돌릴 때 사용.
+ * 다른 상대와의 매칭은 유지되며, 각 후보의 status는 남은 매칭 기준으로 재계산된다.
+ */
+export async function unmatchPair(
+  candidateAId: string,
+  candidateBId: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const membership = await requireMembership();
+
+  if (!canEditCandidates(membership.role)) {
+    return { ok: false, message: "권한이 없습니다." };
+  }
+
+  const supabase = await createClient();
+
+  if (!supabase) {
+    return { ok: false, message: "Supabase 환경변수가 없습니다." };
+  }
+
+  if (!candidateAId || !candidateBId || candidateAId === candidateBId) {
+    return { ok: false, message: "후보 정보를 올바르게 선택해주세요." };
+  }
+
+  const { error: closeError } = await supabase
+    .from("cupid_match_records")
+    .update({
+      outcome: "closed",
+      summary: UNMATCH_TO_ACTIVE_SUMMARY,
+      happened_on: new Date().toISOString().slice(0, 10),
+    })
+    .or(buildPairMatchRecordsOrFilter(candidateAId, candidateBId))
+    .neq("outcome", "closed");
+
+  if (closeError) {
+    return { ok: false, message: closeError.message };
+  }
+
+  await recomputeCandidateStatus(supabase, candidateAId);
+  await recomputeCandidateStatus(supabase, candidateBId);
+
+  revalidateDashboardCaches([candidateAId, candidateBId]);
+  return { ok: true };
 }
 
 export async function createMatchRecord(formData: FormData) {
@@ -943,7 +1147,10 @@ export async function closeMatchWithRecord(formData: FormData) {
     );
   }
 
-  if (!source.paired_candidate_id) {
+  // 종료할 상대를 명시적으로 지정할 수 있다 (1:N). 미지정 시 대표 상대(paired_candidate_id) 사용.
+  const counterpartId = cleanText(formData.get("counterpartId")) || source.paired_candidate_id;
+
+  if (!counterpartId) {
     redirect(
       `/profiles/${candidateId}?message=${encodeURIComponent("연결된 상대가 없어 매칭 종료 기록을 남길 수 없습니다.")}`,
     );
@@ -952,7 +1159,7 @@ export async function closeMatchWithRecord(formData: FormData) {
   const { data: counterpart, error: counterpartError } = await supabase
     .from("cupid_candidates")
     .select("id, full_name, birth_year, region, occupation")
-    .eq("id", source.paired_candidate_id)
+    .eq("id", counterpartId)
     .maybeSingle();
 
   if (counterpartError || !counterpart) {
@@ -1017,14 +1224,10 @@ export async function closeMatchWithRecord(formData: FormData) {
     }
   }
 
-  const { error: updateError } = await supabase
-    .from("cupid_candidates")
-    .update({ status: "active", paired_candidate_id: null })
-    .in("id", [source.id, counterpart.id]);
-
-  if (updateError) {
-    redirect(`/profiles/${candidateId}?message=${encodeURIComponent(updateError.message)}`);
-  }
+  // 1:N — 종료 후 각 후보의 status를 남은 매칭 기준으로 재계산
+  // (다른 진행중 매칭이 있으면 matched 유지, 없으면 active로 복귀)
+  await recomputeCandidateStatus(supabase, source.id);
+  await recomputeCandidateStatus(supabase, counterpart.id);
 
   revalidateDashboardCaches([source.id, counterpart.id]);
   redirect(`/profiles/${candidateId}?message=match-closed`);

--- a/lib/match-flow-columns.ts
+++ b/lib/match-flow-columns.ts
@@ -5,6 +5,29 @@ export const ONGOING_MATCH_OUTCOMES: MatchOutcome[] = ["intro_sent", "first_meet
 
 export type MatchFlowColumnKey = "progress" | "completed" | "terminated";
 
+/** 현재 매칭 관계 한 쌍 (정렬된 후보 id 쌍). 1:N 매칭 레인 렌더의 단일 진실 소스 */
+export type ActiveMatchPair = { aId: string; bId: string };
+
+/**
+ * closed가 아닌 매칭 레코드(진행중 + 커플)에서 현재 매칭 관계 쌍을 도출한다.
+ * 같은 관계가 양쪽 후보에 각각 저장되므로 정렬된 쌍 기준으로 1건만 남긴다.
+ */
+export function buildActiveMatchPairs(records: MatchRecord[]): ActiveMatchPair[] {
+  const seen = new Set<string>();
+  const pairs: ActiveMatchPair[] = [];
+  for (const record of records) {
+    if (record.outcome === "closed") continue;
+    const partnerId = record.counterpart_candidate_id;
+    if (!partnerId) continue;
+    const [aId, bId] = [record.candidate_id, partnerId].sort();
+    const key = `${aId}:${bId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    pairs.push({ aId, bId });
+  }
+  return pairs;
+}
+
 export function buildPairMatchRecordsOrFilter(candidateAId: string, candidateBId: string) {
   return `and(candidate_id.eq.${candidateAId},counterpart_candidate_id.eq.${candidateBId}),and(candidate_id.eq.${candidateBId},counterpart_candidate_id.eq.${candidateAId})`;
 }


### PR DESCRIPTION
Add first-class support for 1:N matching relationships across the dashboard and admin actions. Introduces ActiveMatchPair and buildActiveMatchPairs (lib/match-flow-columns) and threads activeMatchPairs through dashboard components to render paired lanes correctly. Update pair card draggable ids with buildPairDraggableId/parsePairDraggableId to encode both member ids and avoid id collisions. Enhance DashboardFlowBoard drag/drop logic to handle relationship-level drags, show pair overlays, and provide an unmatch action (unmatchPair) that closes a single relationship and recomputes candidate status. Revise admin-actions to compute open match partners, recompute candidate status from non-closed match records, close other matches when confirming a couple, and close all matches when reverting to active. Update profile and operator UI to display multiple current partners and allow selecting a counterpart when closing a match. Minor UI tweak: make the stat bar record cell link to /timeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented 1:N matching support—candidates can now maintain multiple active partnerships simultaneously
  * Made pair cards draggable for easier match management in the flow board
  * Added clickable navigation link from stats dashboard to timeline
  * Added partner selection dropdown when closing matches with multiple active partners

* **Refactor**
  * Improved match relationship tracking and deduplication logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->