### PR TITLE
Expose getActiveMatchPairs and merge pair sources

### DIFF
--- a/app/(member)/dashboard/_components/dashboard-main.tsx
+++ b/app/(member)/dashboard/_components/dashboard-main.tsx
@@ -1,6 +1,10 @@
 import { ManagerDashboard } from "./manager-dashboard";
-import { buildTimelineEvents, getDashboardCandidates, getDashboardTimelineData } from "@/lib/data";
-import { buildActiveMatchPairs } from "@/lib/match-flow-columns";
+import {
+  buildTimelineEvents,
+  getActiveMatchPairs,
+  getDashboardCandidates,
+  getDashboardTimelineData,
+} from "@/lib/data";
 import { DashboardViewMode } from "@/lib/types";
 import type { Membership } from "@/lib/types";
 
@@ -10,16 +14,16 @@ type DashboardMainProps = {
 };
 
 export async function DashboardMain({ membership, initialView }: DashboardMainProps) {
-  const [candidates, timelineData] = await Promise.all([
+  const [candidates, timelineData, activeMatchPairs] = await Promise.all([
     getDashboardCandidates(),
     getDashboardTimelineData(),
+    getActiveMatchPairs(),
   ]);
 
   const timelineEvents = buildTimelineEvents(
     timelineData.records,
     new Map(candidates.map((candidate) => [candidate.id, candidate])),
   );
-  const activeMatchPairs = buildActiveMatchPairs(timelineData.records);
 
   return (
     <ManagerDashboard

--- a/app/(member)/dashboard/_components/flow-board-paired-lane.tsx
+++ b/app/(member)/dashboard/_components/flow-board-paired-lane.tsx
@@ -42,8 +42,10 @@ function toLaneRow(
   return male || female ? { male, female } : { male: first, female: second };
 }
 
-// 현재 매칭 관계(activeMatchPairs) 기준으로 페어 행을 만든다.
-// 1:N에서는 한 후보가 여러 관계에 속할 수 있어 같은 후보가 여러 행에 등장한다.
+// 현재 매칭 관계로 페어 행을 만든다. 관계 소스는 두 가지의 합집합:
+//  (1) activeMatchPairs — 매칭 레코드 기반 (1:N 관계)
+//  (2) paired_candidate_id — 신뢰 가능한 대표 페어 (레코드 없는 레거시 커플/매칭 보강)
+// 한 후보가 여러 관계에 속하면 같은 후보가 여러 행에 등장한다.
 function buildPairedLaneRows(
   laneItems: DashboardBoardCandidate[],
   activeMatchPairs: ActiveMatchPair[],
@@ -53,21 +55,33 @@ function buildPairedLaneRows(
   const seenPairKeys = new Set<string>();
   const pairedCandidateIds = new Set<string>();
 
-  for (const pair of activeMatchPairs) {
-    const first = byId.get(pair.aId);
-    const second = byId.get(pair.bId);
-    if (!first || !second) continue;
+  const addPair = (aId: string, bId: string) => {
+    const first = byId.get(aId);
+    const second = byId.get(bId);
+    if (!first || !second) return;
 
-    const key = [pair.aId, pair.bId].sort().join(":");
-    if (seenPairKeys.has(key)) continue;
+    const key = [aId, bId].sort().join(":");
+    if (seenPairKeys.has(key)) return;
     seenPairKeys.add(key);
 
     pairedCandidateIds.add(first.id);
     pairedCandidateIds.add(second.id);
     rows.push(toLaneRow(first, second));
+  };
+
+  // (1) 매칭 레코드 기반 관계
+  for (const pair of activeMatchPairs) {
+    addPair(pair.aId, pair.bId);
   }
 
-  // 관계 쌍이 잡히지 않은 잔여 후보(레코드 누락 등)는 한쪽만 채운 행으로 표시
+  // (2) paired_candidate_id 기반 관계 (레거시·대표 페어 보강)
+  for (const candidate of laneItems) {
+    if (candidate.paired_candidate_id) {
+      addPair(candidate.id, candidate.paired_candidate_id);
+    }
+  }
+
+  // 어느 관계에도 잡히지 않은 잔여 후보만 한쪽만 채운 행으로 표시
   for (const candidate of laneItems) {
     if (pairedCandidateIds.has(candidate.id)) continue;
     if (candidate.gender === "여") {

--- a/components/profile-detail-content.tsx
+++ b/components/profile-detail-content.tsx
@@ -82,11 +82,15 @@ export async function ProfileDetailContent({ id, message, membership }: ProfileD
   ];
 
   // 현재 매칭 상대는 진행중/커플(closed가 아닌) 매칭 레코드에서 도출 (1:N).
+  // 레코드가 없는 레거시 커플/매칭 보강을 위해 paired_candidate_id도 합집합으로 포함.
   const currentPartnerIds = [
     ...new Set(
-      records
-        .filter((record) => record.outcome !== "closed" && record.counterpart_candidate_id)
-        .map((record) => record.counterpart_candidate_id as string),
+      [
+        ...records
+          .filter((record) => record.outcome !== "closed" && record.counterpart_candidate_id)
+          .map((record) => record.counterpart_candidate_id as string),
+        ...(candidate.paired_candidate_id ? [candidate.paired_candidate_id] : []),
+      ],
     ),
   ];
 

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -5,6 +5,7 @@ import {
   TAG_DASHBOARD_TIMELINE,
 } from "@/lib/cache-tags";
 import { isDirectImageUrl } from "@/lib/image-url-utils";
+import { buildActiveMatchPairs, type ActiveMatchPair } from "@/lib/match-flow-columns";
 import { unstable_cache } from "next/cache";
 import { mockCandidates, mockMatchRecords, mockMemberships } from "@/lib/mock-data";
 import {
@@ -605,6 +606,35 @@ export async function getDashboardTimelineData(): Promise<{
   totalCount: number;
 }> {
   return unstable_cache(loadDashboardTimelineDataUncached, ["cupid-dashboard-timeline-data"], {
+    tags: [TAG_DASHBOARD_TIMELINE],
+    revalidate: 90,
+  })();
+}
+
+async function loadActiveMatchPairsUncached(): Promise<ActiveMatchPair[]> {
+  const supabase = await createClient();
+
+  if (!supabase) {
+    return buildActiveMatchPairs(mockMatchRecords);
+  }
+
+  // 현재 매칭(진행중+커플)만 도출 — closed가 아닌 레코드는 소수이므로 limit 없이 조회한다.
+  const { data, error } = await supabase
+    .from("cupid_match_records")
+    .select(
+      "id, candidate_id, counterpart_label, counterpart_candidate_id, matchmaker_name, outcome, summary, happened_on",
+    )
+    .neq("outcome", "closed");
+
+  if (error || !data) {
+    return buildActiveMatchPairs(mockMatchRecords);
+  }
+
+  return buildActiveMatchPairs(data.map(mapMatchRecord));
+}
+
+export async function getActiveMatchPairs(): Promise<ActiveMatchPair[]> {
+  return unstable_cache(loadActiveMatchPairsUncached, ["cupid-active-match-pairs"], {
     tags: [TAG_DASHBOARD_TIMELINE],
     revalidate: 90,
   })();


### PR DESCRIPTION
Add a cached getActiveMatchPairs() in lib/data that queries supabase for non-closed match records (with a mock fallback) and reuses buildActiveMatchPairs. Update DashboardMain to fetch activeMatchPairs from the data layer. Update pairing logic in flow-board-paired-lane to build paired rows from the union of activeMatchPairs and candidate.paired_candidate_id (legacy/representative pairs), with deduplication via seenPairKeys and an addPair helper. Also include paired_candidate_id when deriving current partners in profile-detail-content. These changes centralize active-pair loading and strengthen handling of legacy/no-record pairings.