### PR TITLE
Reduce sakura petals, add reduced-motion & cache

### DIFF
--- a/app/(member)/dashboard/_components/manager-dashboard.tsx
+++ b/app/(member)/dashboard/_components/manager-dashboard.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { DashboardWorkspace } from "./dashboard-workspace";
 import { SakuraRain } from "@/components/sakura-rain";
 import { DashboardViewMode } from "@/lib/types";
@@ -23,7 +21,7 @@ export function ManagerDashboard({
 }: ManagerDashboardProps) {
   return (
     <div className="relative min-h-dvh bg-gradient-to-br from-rose-50 to-orange-50/50 text-slate-800">
-      <SakuraRain petalCount={62} />
+      <SakuraRain />
       <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(ellipse_at_22%_0%,rgba(255,228,230,0.6),transparent_46%),radial-gradient(ellipse_at_82%_28%,rgba(255,237,213,0.48),transparent_42%),radial-gradient(circle_at_50%_100%,rgba(255,241,242,0.52),transparent_55%)]" />
 
       <main className="relative z-10 mx-auto flex w-full max-w-[1440px] flex-col gap-8 overflow-x-hidden px-4 pb-6 pt-24 md:px-8 lg:px-12">

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -16,7 +16,7 @@ export default async function HomePage() {
 
   return (
     <main className="min-h-screen overflow-x-hidden bg-gradient-to-br from-rose-50 via-pink-50/30 to-orange-50/50">
-      <SakuraRain petalCount={56} />
+      <SakuraRain petalCount={40} />
       <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(circle_at_top,rgba(255,242,245,0.84),rgba(255,247,243,0.68),rgba(255,255,255,0.38))]" />
 
       <GlobalNav membership={isLoggedIn ? membership : null} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,6 +139,17 @@
   filter: drop-shadow(0 8px 14px rgba(251, 113, 133, 0.12));
 }
 
+/* 모션 최소화 사용자에게는 상시 애니메이션 부담을 제거 */
+@media (prefers-reduced-motion: reduce) {
+  .sakura-petal-track,
+  .sakura-petal-drift {
+    animation: none;
+  }
+  .sakura-petal-track {
+    display: none;
+  }
+}
+
 @keyframes sakura-fall {
   0% {
     opacity: 0;

--- a/components/pending-invite-view.tsx
+++ b/components/pending-invite-view.tsx
@@ -36,7 +36,7 @@ export function PendingInviteView({
 
   return (
     <main className="flex min-h-screen flex-col items-center overflow-x-hidden bg-gradient-to-br from-rose-50 via-pink-50/30 to-orange-50/50 px-4 py-10 lg:py-16">
-      <SakuraRain petalCount={56} />
+      <SakuraRain petalCount={40} />
       <div className="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(circle_at_top,rgba(255,242,245,0.84),rgba(255,247,243,0.68),rgba(255,255,255,0.38))]" />
       <PendingStatusGuard />
 

--- a/components/sakura-rain.tsx
+++ b/components/sakura-rain.tsx
@@ -52,11 +52,11 @@ function createSakuraPetals(count: number) {
 }
 
 type SakuraRainProps = {
-  /** 최소 50개 권장 — 기본 60 */
+  /** 기본 36 — 노드/페인트 비용을 줄이기 위해 과도한 수는 지양 */
   petalCount?: number;
 };
 
-export function SakuraRain({ petalCount = 60 }: SakuraRainProps) {
+export function SakuraRain({ petalCount = 36 }: SakuraRainProps) {
   const petals = useMemo(() => createSakuraPetals(petalCount), [petalCount]);
 
   return (

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -207,17 +207,24 @@ async function getMembershipFullNameByUserId(
     return undefined;
   }
 
-  const { data, error } = await supabase
-    .from("cupid_memberships")
-    .select("full_name")
-    .eq("user_id", userId)
-    .maybeSingle();
+  // 멤버십 이름은 거의 변하지 않음 — 동일 작성자의 후보가 여럿일 때 반복 쿼리 방지
+  return unstable_cache(
+    async () => {
+      const { data, error } = await supabase
+        .from("cupid_memberships")
+        .select("full_name")
+        .eq("user_id", userId)
+        .maybeSingle();
 
-  if (error || !data?.full_name) {
-    return undefined;
-  }
+      if (error || !data?.full_name) {
+        return undefined;
+      }
 
-  return data.full_name;
+      return data.full_name;
+    },
+    ["membership-full-name", userId],
+    { revalidate: PROFILE_CONTENT_CACHE_SECONDS },
+  )();
 }
 
 function mapMatchRecord(row: any): MatchRecord {

--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,10 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     remotePatterns: supabaseRemotePatterns,
   },
+  experimental: {
+    // barrel import 패키지의 트리셰이킹을 개선해 초기 번들 크기 감소
+    optimizePackageImports: ["lucide-react", "date-fns"],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Lowered SakuraRain default count (60→36) and reduced explicit instances (56→40) to cut paint/node cost; removed explicit petalCount in manager dashboard. Added prefers-reduced-motion rule to globals.css to disable sakura animations and hide the petal track for motion-sensitive users. Wrapped getMembershipFullNameByUserId DB query in unstable_cache with a revalidate TTL to avoid repeated queries. Enabled experimental optimizePackageImports for lucide-react and date-fns in next.config to improve tree-shaking. Also removed a "use client" directive from the manager dashboard component.